### PR TITLE
feat: implementar US-004 avance de turnos

### DIFF
--- a/app/api/matches/[matchId]/turns/advance/route.ts
+++ b/app/api/matches/[matchId]/turns/advance/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { advanceTurnResponseSchema } from '@/lib/domain/schemas';
+import { jsonError, toValidationIssues } from '@/lib/api/http-errors';
+import { advanceTurn } from '@/lib/matches/lifecycle';
+
+type RouteContext = {
+  params: Promise<{ matchId: string }>;
+};
+
+export async function POST(_request: Request, context: RouteContext) {
+  const { matchId } = await context.params;
+  const result = advanceTurn(matchId);
+
+  if (!result.ok) {
+    const status = result.error.code === 'MATCH_NOT_FOUND' ? 404 : 409;
+    return jsonError(result.error.code, result.error.message, status);
+  }
+
+  const parsedResponse = advanceTurnResponseSchema.safeParse(result.value);
+  if (!parsedResponse.success) {
+    return jsonError('INTERNAL_CONTRACT_ERROR', 'Response contract validation failed.', 500, {
+      issues: toValidationIssues(parsedResponse.error.issues)
+    });
+  }
+
+  return NextResponse.json(parsedResponse.data, { status: 200 });
+}

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -104,6 +104,24 @@ export type StartMatchResponse = {
   turn_number: 0;
 };
 
+export type AdvanceTurnEventResponse = {
+  id: string;
+  type: EventType;
+  narrative_text: string;
+  participant_ids: string[];
+};
+
+export type AdvanceTurnResponse = {
+  turn_number: number;
+  cycle_phase: CyclePhase;
+  tension_level: number;
+  event: AdvanceTurnEventResponse;
+  survivors_count: number;
+  eliminated_ids: string[];
+  finished: boolean;
+  winner_id: string | null;
+};
+
 export type GetMatchStateResponse = {
   match_id: string;
   phase: MatchPhase;

--- a/lib/matches/lifecycle.ts
+++ b/lib/matches/lifecycle.ts
@@ -1,5 +1,6 @@
 import { RULESET_VERSION } from '@/lib/domain/types';
 import type {
+  AdvanceTurnResponse,
   CreateMatchRequest,
   CreateMatchResponse,
   GetMatchStateResponse,
@@ -7,6 +8,13 @@ import type {
   ParticipantState,
   StartMatchResponse
 } from '@/lib/domain/types';
+import type { EventTemplate, SeededRng } from '@/lib/simulation-state';
+import {
+  advanceDirector,
+  createSeededRng,
+  sampleParticipantCount,
+  selectCatalogEvent
+} from '@/lib/simulation-state';
 
 type StoredMatch = {
   match: Match;
@@ -17,17 +25,104 @@ type StoredMatch = {
 
 const matches = new Map<string, StoredMatch>();
 
-type StartMatchErrorCode = 'MATCH_NOT_FOUND' | 'MATCH_STATE_CONFLICT';
+const MAX_RECENT_EVENTS = 12;
+
+const TURN_EVENT_CATALOG: EventTemplate[] = [
+  { id: 'combat-1', type: 'combat', base_weight: 10, phases: ['bloodbath', 'day', 'night'] },
+  { id: 'combat-2', type: 'combat', base_weight: 8, phases: ['bloodbath', 'day', 'night'] },
+  { id: 'alliance-1', type: 'alliance', base_weight: 6, phases: ['day', 'night', 'finale'] },
+  { id: 'betrayal-1', type: 'betrayal', base_weight: 7, phases: ['day', 'night', 'finale'] },
+  { id: 'resource-1', type: 'resource', base_weight: 5, phases: ['day', 'night'] },
+  { id: 'hazard-1', type: 'hazard', base_weight: 6, phases: ['bloodbath', 'night', 'finale'] },
+  { id: 'surprise-1', type: 'surprise', base_weight: 4, phases: ['day', 'night', 'finale'] }
+];
+
+type LifecycleErrorCode = 'MATCH_NOT_FOUND' | 'MATCH_STATE_CONFLICT';
 
 type StartMatchResult =
   | { ok: true; value: StartMatchResponse }
   | {
       ok: false;
       error: {
-        code: StartMatchErrorCode;
+        code: LifecycleErrorCode;
         message: string;
       };
     };
+
+type AdvanceTurnResult =
+  | { ok: true; value: AdvanceTurnResponse }
+  | {
+      ok: false;
+      error: {
+        code: LifecycleErrorCode;
+        message: string;
+      };
+    };
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function aliveParticipants(participants: ParticipantState[]): ParticipantState[] {
+  return participants.filter((participant) => participant.status !== 'eliminated');
+}
+
+function chooseParticipants(
+  participants: ParticipantState[],
+  count: number,
+  rng: SeededRng
+): ParticipantState[] {
+  const selected: ParticipantState[] = [];
+  const pool = [...participants];
+  const maxCount = Math.min(count, participants.length);
+
+  for (let index = 0; index < maxCount; index += 1) {
+    const chosenIndex = Math.floor(rng() * pool.length);
+    const [chosen] = pool.splice(chosenIndex, 1);
+    selected.push(chosen);
+  }
+
+  return selected;
+}
+
+function eliminationChance(
+  cyclePhase: Match['cycle_phase'],
+  tensionLevel: number,
+  aliveCount: number
+): number {
+  const phaseBase: Record<Match['cycle_phase'], number> = {
+    bloodbath: 0.34,
+    day: 0.22,
+    night: 0.28,
+    finale: 0.72
+  };
+
+  const tensionFactor = tensionLevel / 300;
+  const endgameFactor = aliveCount <= 4 ? 0.08 : 0;
+  return clamp(phaseBase[cyclePhase] + tensionFactor + endgameFactor, 0, 0.95);
+}
+
+function eventNarrative(
+  templateId: string,
+  cyclePhase: Match['cycle_phase'],
+  participantCount: number,
+  eliminatedCount: number
+): string {
+  const eliminationSuffix =
+    eliminatedCount > 0
+      ? ` Hubo ${eliminatedCount} eliminacion${eliminatedCount > 1 ? 'es' : ''}.`
+      : ' Nadie fue eliminado.';
+  return `Evento ${templateId} en fase ${cyclePhase} con ${participantCount} participante(s).${eliminationSuffix}`;
+}
+
+function resolveWinnerId(participants: ParticipantState[]): string | null {
+  const alive = aliveParticipants(participants);
+  if (alive.length !== 1) {
+    return null;
+  }
+
+  return alive[0].id;
+}
 
 export function createMatch(input: CreateMatchRequest): CreateMatchResponse {
   const matchId = crypto.randomUUID();
@@ -121,6 +216,152 @@ export function getMatchState(matchId: string): GetMatchStateResponse | null {
     settings: stored.settings,
     participants: stored.participants,
     recent_events: stored.recent_events
+  };
+}
+
+export function advanceTurn(matchId: string): AdvanceTurnResult {
+  const stored = matches.get(matchId);
+  if (!stored) {
+    return {
+      ok: false,
+      error: {
+        code: 'MATCH_NOT_FOUND',
+        message: 'Match not found.'
+      }
+    };
+  }
+
+  if (stored.match.phase !== 'running') {
+    return {
+      ok: false,
+      error: {
+        code: 'MATCH_STATE_CONFLICT',
+        message: `Match cannot advance from phase "${stored.match.phase}".`
+      }
+    };
+  }
+
+  const alive = aliveParticipants(stored.participants);
+  if (alive.length <= 1) {
+    return {
+      ok: false,
+      error: {
+        code: 'MATCH_STATE_CONFLICT',
+        message: 'Match is already resolved.'
+      }
+    };
+  }
+
+  const currentPhase = stored.match.cycle_phase;
+  const nextTurnNumber = stored.match.turn_number + 1;
+  const rng = createSeededRng(`${stored.match.seed ?? stored.match.id}:${nextTurnNumber}`);
+  const participantCount = sampleParticipantCount(alive.length, rng);
+  const selectedParticipants = chooseParticipants(alive, participantCount, rng);
+  const recentTemplateIds = stored.recent_events.slice(-4).map((event) => event.template_id);
+  const selectedTemplate = selectCatalogEvent(
+    TURN_EVENT_CATALOG,
+    currentPhase,
+    recentTemplateIds,
+    rng,
+    2
+  );
+  const hadElimination =
+    alive.length > 1 &&
+    (alive.length === 2 || rng() < eliminationChance(currentPhase, stored.match.tension_level, alive.length));
+
+  const eliminatedIds: string[] = [];
+  if (hadElimination) {
+    const eliminatedIndex = Math.floor(rng() * selectedParticipants.length);
+    const eliminatedParticipant = selectedParticipants[eliminatedIndex];
+    eliminatedIds.push(eliminatedParticipant.id);
+
+    const target = stored.participants.find((participant) => participant.id === eliminatedParticipant.id);
+    if (target) {
+      target.status = 'eliminated';
+      target.current_health = 0;
+    }
+  }
+
+  for (const participant of selectedParticipants) {
+    if (!eliminatedIds.includes(participant.id)) {
+      const mutable = stored.participants.find((item) => item.id === participant.id);
+      if (mutable) {
+        mutable.streak_score += 1;
+      }
+    }
+  }
+
+  const survivorsCount = alive.length - eliminatedIds.length;
+  const nextDirector = advanceDirector(
+    {
+      turn_number: stored.match.turn_number,
+      cycle_phase: stored.match.cycle_phase,
+      alive_count: alive.length,
+      tension_level: stored.match.tension_level
+    },
+    eliminatedIds.length > 0,
+    survivorsCount
+  );
+
+  const eventCreatedAt = new Date().toISOString();
+  const event = {
+    id: crypto.randomUUID(),
+    match_id: stored.match.id,
+    template_id: selectedTemplate.id,
+    turn_number: nextTurnNumber,
+    type: selectedTemplate.type,
+    phase: currentPhase,
+    participant_count: selectedParticipants.length,
+    intensity: clamp(
+      Math.round(stored.match.tension_level + 15 + rng() * 40 + (eliminatedIds.length > 0 ? 20 : 0)),
+      0,
+      100
+    ),
+    narrative_text: eventNarrative(
+      selectedTemplate.id,
+      currentPhase,
+      selectedParticipants.length,
+      eliminatedIds.length
+    ),
+    lethal: eliminatedIds.length > 0,
+    created_at: eventCreatedAt
+  } satisfies GetMatchStateResponse['recent_events'][number];
+
+  stored.recent_events = [...stored.recent_events, event].slice(-MAX_RECENT_EVENTS);
+  stored.match = {
+    ...stored.match,
+    turn_number: nextDirector.turn_number,
+    cycle_phase: nextDirector.cycle_phase,
+    tension_level: nextDirector.tension_level
+  };
+
+  const winnerId = resolveWinnerId(stored.participants);
+  const finished = winnerId !== null;
+  if (finished) {
+    stored.match = {
+      ...stored.match,
+      phase: 'finished',
+      ended_at: eventCreatedAt
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      turn_number: stored.match.turn_number,
+      cycle_phase: stored.match.cycle_phase,
+      tension_level: stored.match.tension_level,
+      event: {
+        id: event.id,
+        type: event.type,
+        narrative_text: event.narrative_text,
+        participant_ids: selectedParticipants.map((participant) => participant.id)
+      },
+      survivors_count: survivorsCount,
+      eliminated_ids: eliminatedIds,
+      finished,
+      winner_id: winnerId
+    }
   };
 }
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/specs/plans/kanban.md
+++ b/specs/plans/kanban.md
@@ -4,7 +4,6 @@
 - `US-002` Ciclo de vida base
 - `US-003A` Motor + director + catalogo
 - `US-003B` Setup UX + menu local
-- `US-004` Avance de turnos
 - `US-005A` UX simulacion en vivo
 - `US-005B` Continuidad local
 - `US-006A` Final + replay
@@ -21,3 +20,4 @@
 
 ## DONE
 - `US-001` Contratos y modelo base
+- `US-004` Avance de turnos

--- a/specs/plans/stories/04-US-004.md
+++ b/specs/plans/stories/04-US-004.md
@@ -1,6 +1,6 @@
 # 04 - US-004 - Avance de turnos server-authoritative
 
-- Estado: `TODO`
+- Estado: `DONE`
 - Priority: `P0`
 - Dependencies: `US-003A`, `US-003B`
 

--- a/specs/plans/work-plan.md
+++ b/specs/plans/work-plan.md
@@ -66,7 +66,7 @@
 - Story file: `specs/plans/stories/03-US-003B.md`
 
 ### 04 - US-004 - Avance de turnos server-authoritative
-- Estado: `TODO`
+- Estado: `DONE`
 - As a jugador, I want avance consistente por turno, so that la partida termine con ganador unico.
 - Acceptance criteria:
   - Given partida running, when `POST /turns/advance`, then genera 1 evento y actualiza estado.

--- a/tests/domain-contracts.test.ts
+++ b/tests/domain-contracts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  advanceTurnResponseSchema,
   createMatchRequestSchema,
   getMatchStateResponseSchema,
   matchSnapshotSchema,
@@ -133,5 +134,25 @@ describe('match lifecycle response contracts', () => {
     };
 
     expect(getMatchStateResponseSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('accepts advance_turn response contract', () => {
+    const payload = {
+      turn_number: 1,
+      cycle_phase: 'day',
+      tension_level: 12,
+      event: {
+        id: 'event-1',
+        type: 'combat',
+        narrative_text: 'Evento combat-1 en fase bloodbath con 2 participante(s). Hubo 1 eliminacion.',
+        participant_ids: ['participant-1', 'participant-2']
+      },
+      survivors_count: 9,
+      eliminated_ids: ['participant-2'],
+      finished: false,
+      winner_id: null
+    };
+
+    expect(advanceTurnResponseSchema.parse(payload)).toEqual(payload);
   });
 });

--- a/tests/matches-lifecycle-routes.test.ts
+++ b/tests/matches-lifecycle-routes.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { POST as createMatch } from '@/app/api/matches/route';
 import { GET as getMatchState } from '@/app/api/matches/[matchId]/route';
 import { POST as startMatch } from '@/app/api/matches/[matchId]/start/route';
+import { POST as advanceTurn } from '@/app/api/matches/[matchId]/turns/advance/route';
 import { resetMatchesForTests } from '@/lib/matches/lifecycle';
+import { advanceDirector } from '@/lib/simulation-state';
 
 function roster(size: number): string[] {
   return Array.from({ length: size }, (_, index) => `char-${index + 1}`);
@@ -83,6 +85,170 @@ describe('match lifecycle routes', () => {
         message: 'Match not found.'
       }
     });
+  });
+
+  it('advances one turn and updates runtime state consistently', async () => {
+    const createRequest = new Request('http://localhost/api/matches', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        roster_character_ids: roster(10),
+        settings: {
+          surprise_level: 'normal',
+          event_profile: 'balanced',
+          simulation_speed: '1x',
+          seed: 'us-004-seed'
+        }
+      })
+    });
+
+    const createResponse = await createMatch(createRequest);
+    const createBody = await createResponse.json();
+    const matchId = createBody.match_id as string;
+
+    await startMatch(
+      new Request(`http://localhost/api/matches/${matchId}/start`, { method: 'POST' }),
+      { params: Promise.resolve({ matchId }) }
+    );
+
+    const advanceResponse = await advanceTurn(
+      new Request(`http://localhost/api/matches/${matchId}/turns/advance`, { method: 'POST' }),
+      { params: Promise.resolve({ matchId }) }
+    );
+    const advanceBody = await advanceResponse.json();
+
+    expect(advanceResponse.status).toBe(200);
+    expect(advanceBody.event).toMatchObject({
+      id: expect.any(String),
+      type: expect.any(String),
+      narrative_text: expect.any(String),
+      participant_ids: expect.any(Array)
+    });
+    expect(advanceBody.event.participant_ids.length).toBeGreaterThanOrEqual(1);
+    expect(advanceBody.survivors_count).toBe(10 - advanceBody.eliminated_ids.length);
+    expect(advanceBody.finished).toBe(false);
+    expect(advanceBody.winner_id).toBeNull();
+
+    const expectedDirector = advanceDirector(
+      {
+        turn_number: 0,
+        cycle_phase: 'bloodbath',
+        alive_count: 10,
+        tension_level: 0
+      },
+      advanceBody.eliminated_ids.length > 0,
+      advanceBody.survivors_count
+    );
+
+    expect(advanceBody.turn_number).toBe(expectedDirector.turn_number);
+    expect(advanceBody.cycle_phase).toBe(expectedDirector.cycle_phase);
+    expect(advanceBody.tension_level).toBe(expectedDirector.tension_level);
+
+    const stateResponse = await getMatchState(
+      new Request(`http://localhost/api/matches/${matchId}`, { method: 'GET' }),
+      { params: Promise.resolve({ matchId }) }
+    );
+    const stateBody = await stateResponse.json();
+
+    expect(stateResponse.status).toBe(200);
+    expect(stateBody.turn_number).toBe(advanceBody.turn_number);
+    expect(stateBody.cycle_phase).toBe(advanceBody.cycle_phase);
+    expect(stateBody.tension_level).toBe(advanceBody.tension_level);
+    expect(stateBody.recent_events).toHaveLength(1);
+  });
+
+  it('returns conflict when advancing a match outside running phase', async () => {
+    const createResponse = await createMatch(
+      new Request('http://localhost/api/matches', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          roster_character_ids: roster(10)
+        })
+      })
+    );
+    const createBody = await createResponse.json();
+    const matchId = createBody.match_id as string;
+
+    const response = await advanceTurn(
+      new Request(`http://localhost/api/matches/${matchId}/turns/advance`, { method: 'POST' }),
+      { params: Promise.resolve({ matchId }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error.code).toBe('MATCH_STATE_CONFLICT');
+  });
+
+  it('returns not found when advancing unknown match', async () => {
+    const response = await advanceTurn(
+      new Request('http://localhost/api/matches/missing/turns/advance', { method: 'POST' }),
+      { params: Promise.resolve({ matchId: 'missing' }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({
+      error: {
+        code: 'MATCH_NOT_FOUND',
+        message: 'Match not found.'
+      }
+    });
+  });
+
+  it('finishes match with a unique winner when one survivor remains', async () => {
+    const createResponse = await createMatch(
+      new Request('http://localhost/api/matches', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          roster_character_ids: roster(10),
+          settings: {
+            surprise_level: 'high',
+            event_profile: 'aggressive',
+            simulation_speed: '4x',
+            seed: 'us-004-finish-seed'
+          }
+        })
+      })
+    );
+    const createBody = await createResponse.json();
+    const matchId = createBody.match_id as string;
+
+    await startMatch(
+      new Request(`http://localhost/api/matches/${matchId}/start`, { method: 'POST' }),
+      { params: Promise.resolve({ matchId }) }
+    );
+
+    let lastAdvanceBody: Record<string, unknown> | null = null;
+    for (let index = 0; index < 80; index += 1) {
+      const advanceResponse = await advanceTurn(
+        new Request(`http://localhost/api/matches/${matchId}/turns/advance`, { method: 'POST' }),
+        { params: Promise.resolve({ matchId }) }
+      );
+      lastAdvanceBody = await advanceResponse.json();
+      if (lastAdvanceBody.finished === true) {
+        break;
+      }
+    }
+
+    expect(lastAdvanceBody).not.toBeNull();
+    expect(lastAdvanceBody?.finished).toBe(true);
+    expect(lastAdvanceBody?.survivors_count).toBe(1);
+    expect(typeof lastAdvanceBody?.winner_id).toBe('string');
+
+    const stateResponse = await getMatchState(
+      new Request(`http://localhost/api/matches/${matchId}`, { method: 'GET' }),
+      { params: Promise.resolve({ matchId }) }
+    );
+    const stateBody = await stateResponse.json();
+    const aliveParticipants = (stateBody.participants as Array<{ id: string; status: string }>).filter(
+      (participant) => participant.status !== 'eliminated'
+    );
+
+    expect(stateBody.phase).toBe('finished');
+    expect(aliveParticipants).toHaveLength(1);
+    expect(aliveParticipants[0].id).toBe(lastAdvanceBody?.winner_id);
   });
 
   it('returns consistent state for existing match', async () => {


### PR DESCRIPTION
## Summary\n- implementa endpoint `POST /api/matches/{matchId}/turns/advance`\n- integra avance de turno server-authoritative en runtime store con transiciones de fase/tension\n- agrega cierre de partida con ganador unico y payload `finished/winner_id`\n- agrega cobertura de contratos y lifecycle routes para US-004\n- actualiza estado de US-004 en specs/plans\n\n## Validation\n- npm run validate\n\nFixes #6