### PR TITLE
feat: UX de simulación en vivo (US-005A)

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,0 +1,366 @@
+.page {
+  --bg: #fff5e8;
+  --panel: #fffdf7;
+  --panel-strong: #fff2d6;
+  --border: #f2bf6a;
+  --ink: #2f1e10;
+  --muted: #7d5b3b;
+  --danger: #b93122;
+  --accent: #de6d1a;
+  --accent-2: #1f7a8c;
+  min-height: 100vh;
+  padding: 24px 14px 44px;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(255, 211, 138, 0.45), transparent 46%),
+    radial-gradient(circle at 85% 5%, rgba(210, 87, 39, 0.2), transparent 40%),
+    linear-gradient(165deg, #fffaf0 0%, var(--bg) 100%);
+  color: var(--ink);
+  font-family: 'Avenir Next', 'Futura', 'Trebuchet MS', sans-serif;
+}
+
+.shell {
+  max-width: 1180px;
+  margin: 0 auto;
+  display: grid;
+  gap: 16px;
+}
+
+.hero {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  background: linear-gradient(130deg, rgba(255, 243, 215, 0.9), rgba(255, 255, 255, 0.96));
+  box-shadow: 0 12px 30px rgba(104, 52, 14, 0.12);
+}
+
+.heroTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(1.3rem, 3.2vw, 2.1rem);
+  letter-spacing: 0.02em;
+  font-family: 'Baskerville', 'Georgia', serif;
+}
+
+.heroMeta {
+  margin: 5px 0 0;
+  color: var(--muted);
+}
+
+.kpis {
+  margin-top: 14px;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.kpi {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 9px 10px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.kpiLabel {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.kpiValue {
+  margin-top: 2px;
+  font-size: 1.07rem;
+  font-weight: 700;
+}
+
+.tension {
+  margin-top: 14px;
+  display: grid;
+  gap: 5px;
+}
+
+.tensionTrack {
+  height: 12px;
+  border-radius: 999px;
+  border: 1px solid #cf9d59;
+  background: #f8e3c0;
+  overflow: hidden;
+}
+
+.tensionBar {
+  height: 100%;
+  transition: width 280ms ease;
+  background: linear-gradient(90deg, #dd8e1a 0%, #cd4c1f 55%, #94281e 100%);
+}
+
+.columns {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+  background: var(--panel);
+}
+
+.cardTitle {
+  margin: 0;
+  font-family: 'Baskerville', 'Georgia', serif;
+}
+
+.cardHint {
+  margin: 4px 0 12px;
+  color: var(--muted);
+}
+
+.setupGrid {
+  display: grid;
+  gap: 14px;
+}
+
+.rosterGrid {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+}
+
+.characterToggle {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid #ecc188;
+  border-radius: 9px;
+  padding: 6px 8px;
+  background: #fffbf3;
+  min-height: 38px;
+}
+
+.controlsGrid {
+  display: grid;
+  gap: 9px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.controlLabel {
+  display: grid;
+  gap: 5px;
+  font-size: 0.94rem;
+}
+
+.inlineControls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.input,
+.select,
+.button {
+  border: 1px solid #d8a768;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+
+.input,
+.select {
+  background: #fff;
+}
+
+.button {
+  background: linear-gradient(180deg, #fff7de, #ffdca2);
+  color: #49280f;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.button:hover {
+  filter: brightness(0.98);
+}
+
+.button:disabled {
+  opacity: 0.58;
+  cursor: not-allowed;
+}
+
+.buttonGhost {
+  background: #fff;
+}
+
+.eventShell {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.speedControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.speedButton {
+  border: 1px solid #ce9247;
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: #fff9ed;
+  color: #5f3b16;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.speedButtonActive {
+  background: linear-gradient(180deg, #e47f24, #c5521e);
+  color: #fff;
+  border-color: #b94619;
+}
+
+.feedFilters {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.feedList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.feedItem {
+  border: 1px solid #e6b877;
+  border-radius: 12px;
+  padding: 10px 11px;
+  background: #fffef9;
+}
+
+.feedItemNew {
+  animation: popIn 420ms ease;
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+    background: #ffe3b5;
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    background: #fffef9;
+  }
+}
+
+.feedMeta {
+  margin: 0;
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.feedHeadline {
+  margin: 4px 0 3px;
+  font-weight: 700;
+}
+
+.feedImpact {
+  margin: 0;
+  color: #5b3e22;
+}
+
+.tagRow {
+  margin-top: 7px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag {
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 0.78rem;
+  background: #ffe9c4;
+  color: #5b3813;
+}
+
+.sideGrid {
+  display: grid;
+  gap: 14px;
+}
+
+.participantList,
+.relationsList,
+.matchList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.participantItem,
+.relationItem,
+.matchItem {
+  border: 1px solid #ebc48c;
+  border-radius: 10px;
+  padding: 8px 9px;
+  background: #fffdf5;
+}
+
+.status {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.statusAlive {
+  color: #247454;
+}
+
+.statusInjured {
+  color: #9f5e00;
+}
+
+.statusEliminated {
+  color: var(--danger);
+}
+
+.relationPositive {
+  color: #1a6f57;
+}
+
+.relationNegative {
+  color: #9d2e20;
+}
+
+.info {
+  margin: 10px 0 0;
+  color: #603b17;
+  font-weight: 600;
+}
+
+@media (min-width: 980px) {
+  .columns {
+    grid-template-columns: 360px minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .eventShell {
+    grid-template-columns: minmax(0, 1fr) 300px;
+    align-items: start;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import styles from './page.module.css';
 import {
   createLocalMatchFromSetup,
   getSetupValidation,
@@ -8,6 +9,17 @@ import {
   saveLocalMatchesToStorage,
   type LocalMatchSummary
 } from '@/lib/local-matches';
+import type {
+  AdvanceTurnResponse,
+  CreateMatchResponse,
+  CyclePhase,
+  EventType,
+  GetMatchStateResponse,
+  MatchPhase,
+  ParticipantState,
+  SimulationSpeed,
+  StartMatchResponse
+} from '@/lib/domain/types';
 
 const CHARACTER_OPTIONS = [
   { id: 'char-01', name: 'Atlas' },
@@ -23,15 +35,68 @@ const CHARACTER_OPTIONS = [
   { id: 'char-11', name: 'Vex' },
   { id: 'char-12', name: 'Sage' }
 ];
+
 const DEFAULT_CHARACTERS = CHARACTER_OPTIONS.slice(0, 10).map((character) => character.id);
-const DEFAULT_SIMULATION_SPEED = '1x' as const;
+const DEFAULT_SIMULATION_SPEED: SimulationSpeed = '1x';
 const DEFAULT_EVENT_PROFILE = 'balanced' as const;
 const DEFAULT_SURPRISE_LEVEL = 'normal' as const;
+
+const EVENT_TYPE_LABEL: Record<EventType, string> = {
+  combat: 'Combate',
+  alliance: 'Alianza',
+  betrayal: 'Traicion',
+  resource: 'Recursos',
+  hazard: 'Peligro',
+  surprise: 'Sorpresa'
+};
+
+const EVENT_ACTION: Record<EventType, string> = {
+  combat: 'chocan en combate directo',
+  alliance: 'sellan una alianza estrategica',
+  betrayal: 'rompen la confianza con una traicion',
+  resource: 'aseguran recursos criticos',
+  hazard: 'resisten una amenaza del entorno',
+  surprise: 'quedan atrapados en un giro inesperado'
+};
+
+const SPEED_INTERVAL_MS: Record<SimulationSpeed, number> = {
+  '1x': 1700,
+  '2x': 980,
+  '4x': 560
+};
+
+type PlaybackSpeed = SimulationSpeed | 'pause';
+
+type FeedEvent = {
+  id: string;
+  turn_number: number;
+  phase: CyclePhase;
+  type: EventType;
+  headline: string;
+  impact: string;
+  character_ids: string[];
+  created_at: string;
+};
+
+type SimulationRuntime = {
+  match_id: string;
+  phase: MatchPhase;
+  cycle_phase: CyclePhase;
+  turn_number: number;
+  tension_level: number;
+  settings: GetMatchStateResponse['settings'];
+  participants: ParticipantState[];
+  feed: FeedEvent[];
+  winner_id: string | null;
+};
+
+const EMPTY_FEED: FeedEvent[] = [];
 
 function createBrowserUuid(): string | null {
   if (typeof window === 'undefined' || typeof crypto === 'undefined') {
     return null;
   }
+
   if (typeof crypto.randomUUID !== 'function') {
     return null;
   }
@@ -39,12 +104,204 @@ function createBrowserUuid(): string | null {
   return crypto.randomUUID();
 }
 
+function shortId(value: string): string {
+  return value.slice(0, 8);
+}
+
+function countAlive(participants: ParticipantState[]): number {
+  return participants.filter((participant) => participant.status !== 'eliminated').length;
+}
+
+function characterName(characterId: string): string {
+  return CHARACTER_OPTIONS.find((candidate) => candidate.id === characterId)?.name ?? characterId;
+}
+
+function phaseLabel(phase: CyclePhase | 'setup'): string {
+  const labels: Record<CyclePhase | 'setup', string> = {
+    setup: 'Setup',
+    bloodbath: 'Bloodbath',
+    day: 'Dia',
+    night: 'Noche',
+    finale: 'Finale'
+  };
+
+  return labels[phase];
+}
+
+function statusLabel(status: ParticipantState['status']): string {
+  if (status === 'alive') {
+    return 'Vivo';
+  }
+  if (status === 'injured') {
+    return 'Herido';
+  }
+
+  return 'Eliminado';
+}
+
+function extractErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  if (!('error' in payload)) {
+    return null;
+  }
+
+  const errorValue = (payload as { error?: unknown }).error;
+  if (!errorValue || typeof errorValue !== 'object') {
+    return null;
+  }
+
+  if (!('message' in errorValue)) {
+    return null;
+  }
+
+  const message = (errorValue as { message?: unknown }).message;
+  return typeof message === 'string' ? message : null;
+}
+
+async function requestJson<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, init);
+  const payload = (await response.json().catch(() => null)) as unknown;
+
+  if (!response.ok) {
+    const message =
+      extractErrorMessage(payload) ?? `Request failed (${response.status}) for ${input}`;
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+function feedFromSnapshot(state: GetMatchStateResponse): FeedEvent[] {
+  return [...state.recent_events]
+    .sort((left, right) => right.turn_number - left.turn_number)
+    .map((event) => ({
+      id: event.id,
+      turn_number: event.turn_number,
+      phase: event.phase,
+      type: event.type,
+      headline: event.narrative_text,
+      impact: event.lethal
+        ? 'Impacto: evento letal en el ultimo intercambio.'
+        : 'Impacto: tension sube sin bajas directas.',
+      character_ids: [],
+      created_at: event.created_at
+    }));
+}
+
+function summarizeActors(characterNames: string[]): string {
+  if (characterNames.length === 0) {
+    return 'La arena';
+  }
+
+  if (characterNames.length === 1) {
+    return characterNames[0];
+  }
+
+  if (characterNames.length === 2) {
+    return `${characterNames[0]} y ${characterNames[1]}`;
+  }
+
+  return `${characterNames[0]}, ${characterNames[1]} +${characterNames.length - 2}`;
+}
+
+function impactByType(type: EventType): string {
+  if (type === 'alliance') {
+    return 'Impacto: cohesion tactica en aumento.';
+  }
+
+  if (type === 'betrayal') {
+    return 'Impacto: confianza rota y riesgo social alto.';
+  }
+
+  if (type === 'resource') {
+    return 'Impacto: ventaja temporal de recursos.';
+  }
+
+  if (type === 'hazard') {
+    return 'Impacto: presion ambiental sobre el roster.';
+  }
+
+  if (type === 'surprise') {
+    return 'Impacto: la tension global cambia sin previo aviso.';
+  }
+
+  return 'Impacto: intercambio agresivo entre participantes.';
+}
+
+function feedFromAdvance(
+  advance: AdvanceTurnResponse,
+  participants: ParticipantState[]
+): FeedEvent {
+  const participantsById = new Map(participants.map((participant) => [participant.id, participant]));
+  const characterIds = advance.event.participant_ids
+    .map((participantId) => participantsById.get(participantId)?.character_id)
+    .filter((characterId): characterId is string => Boolean(characterId));
+  const actorNames = characterIds.map((characterId) => characterName(characterId));
+  const eliminatedNames = advance.eliminated_ids
+    .map((participantId) => participantsById.get(participantId)?.character_id)
+    .filter((characterId): characterId is string => Boolean(characterId))
+    .map((characterId) => characterName(characterId));
+
+  const impact =
+    eliminatedNames.length > 0
+      ? `Impacto: ${eliminatedNames.join(', ')} queda fuera de la simulacion.`
+      : impactByType(advance.event.type);
+
+  return {
+    id: advance.event.id,
+    turn_number: advance.turn_number,
+    phase: advance.cycle_phase,
+    type: advance.event.type,
+    headline: `${summarizeActors(actorNames)} ${EVENT_ACTION[advance.event.type]}.`,
+    impact,
+    character_ids: characterIds,
+    created_at: new Date().toISOString()
+  };
+}
+
+function relationDelta(type: EventType): number {
+  if (type === 'alliance' || type === 'resource') {
+    return 2;
+  }
+
+  if (type === 'betrayal') {
+    return -3;
+  }
+
+  if (type === 'combat' || type === 'hazard') {
+    return -1;
+  }
+
+  return 0;
+}
+
+function relationTone(score: number): string {
+  if (score >= 3) {
+    return 'Alianza fuerte';
+  }
+
+  if (score >= 1) {
+    return 'Coordinacion estable';
+  }
+
+  if (score <= -3) {
+    return 'Rivalidad critica';
+  }
+
+  if (score <= -1) {
+    return 'Friccion activa';
+  }
+
+  return 'Relacion neutra';
+}
+
 export default function Home() {
   const [selectedCharacters, setSelectedCharacters] = useState<string[]>(DEFAULT_CHARACTERS);
   const [seed, setSeed] = useState('');
-  const [simulationSpeed, setSimulationSpeed] = useState<'1x' | '2x' | '4x'>(
-    DEFAULT_SIMULATION_SPEED
-  );
+  const [simulationSpeed, setSimulationSpeed] = useState<SimulationSpeed>(DEFAULT_SIMULATION_SPEED);
   const [eventProfile, setEventProfile] = useState<'balanced' | 'aggressive' | 'chaotic'>(
     DEFAULT_EVENT_PROFILE
   );
@@ -54,17 +311,97 @@ export default function Home() {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [localMatches, setLocalMatches] = useState<LocalMatchSummary[]>([]);
   const [openedMatchId, setOpenedMatchId] = useState<string | null>(null);
+  const [runtime, setRuntime] = useState<SimulationRuntime | null>(null);
+  const [playbackSpeed, setPlaybackSpeed] = useState<PlaybackSpeed>('pause');
+  const [filterCharacterId, setFilterCharacterId] = useState<'all' | string>('all');
+  const [filterEventType, setFilterEventType] = useState<'all' | EventType>('all');
   const [infoMessage, setInfoMessage] = useState<string | null>(null);
   const [hasHydrated, setHasHydrated] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const [latestFeedEventId, setLatestFeedEventId] = useState<string | null>(null);
 
   const setupValidation = useMemo(
     () => getSetupValidation(selectedCharacters),
     [selectedCharacters]
   );
+
   const openedMatch = hasHydrated
     ? localMatches.find((match) => match.id === openedMatchId) ?? localMatches[0] ?? null
     : null;
-  const tensionPreview = Math.min(100, 10 + selectedCharacters.length * 4);
+
+  const aliveCount = runtime
+    ? countAlive(runtime.participants)
+    : openedMatch?.alive_count ?? selectedCharacters.length;
+  const totalParticipants = runtime
+    ? runtime.participants.length
+    : openedMatch?.total_participants ?? selectedCharacters.length;
+  const eliminatedCount = Math.max(0, totalParticipants - aliveCount);
+  const currentPhase = runtime?.cycle_phase ?? openedMatch?.cycle_phase ?? 'setup';
+  const currentTurn = runtime?.turn_number ?? openedMatch?.turn_number ?? 0;
+  const tensionValue = runtime?.tension_level ?? Math.min(100, 10 + selectedCharacters.length * 4);
+
+  const feed = runtime?.feed ?? EMPTY_FEED;
+  const filteredFeed = useMemo(
+    () =>
+      feed.filter((event) => {
+        const matchesType = filterEventType === 'all' || event.type === filterEventType;
+        const matchesCharacter =
+          filterCharacterId === 'all' || event.character_ids.includes(filterCharacterId);
+        return matchesType && matchesCharacter;
+      }),
+    [feed, filterCharacterId, filterEventType]
+  );
+
+  const relationHighlights = useMemo(() => {
+    const scoreByPair = new Map<string, { pair: [string, string]; score: number }>();
+
+    for (const event of feed) {
+      if (event.character_ids.length < 2) {
+        continue;
+      }
+
+      const pair: [string, string] = [event.character_ids[0], event.character_ids[1]].sort(
+        (left, right) => left.localeCompare(right)
+      ) as [string, string];
+      const key = `${pair[0]}|${pair[1]}`;
+      const previous = scoreByPair.get(key);
+      const nextScore = (previous?.score ?? 0) + relationDelta(event.type);
+
+      scoreByPair.set(key, {
+        pair,
+        score: nextScore
+      });
+    }
+
+    return [...scoreByPair.values()]
+      .sort((left, right) => Math.abs(right.score) - Math.abs(left.score))
+      .slice(0, 5);
+  }, [feed]);
+
+  const participantStatusList = useMemo(() => {
+    if (!runtime) {
+      return [];
+    }
+
+    return [...runtime.participants].sort((left, right) => {
+      if (left.status === right.status) {
+        return right.current_health - left.current_health;
+      }
+
+      const order: Record<ParticipantState['status'], number> = {
+        alive: 0,
+        injured: 1,
+        eliminated: 2
+      };
+      return order[left.status] - order[right.status];
+    });
+  }, [runtime]);
+
+  const characterFilterOptions = useMemo(() => {
+    const source = runtime?.participants.map((participant) => participant.character_id) ?? selectedCharacters;
+    const unique = [...new Set(source)];
+    return unique.map((characterId) => ({ id: characterId, name: characterName(characterId) }));
+  }, [runtime, selectedCharacters]);
 
   useEffect(() => {
     setHasHydrated(true);
@@ -78,14 +415,25 @@ export default function Home() {
     const { matches, error } = loadLocalMatchesFromStorage(window.localStorage);
     setLocalMatches(matches);
     setOpenedMatchId(matches[0]?.id ?? null);
+
     if (error) {
       setInfoMessage(error);
       return;
     }
+
     if (matches[0]) {
       applySetupFromMatch(matches[0]);
     }
   }, [hasHydrated]);
+
+  const persistLocalMatches = useCallback((nextMatches: LocalMatchSummary[]) => {
+    setLocalMatches(nextMatches);
+
+    const saveResult = saveLocalMatchesToStorage(window.localStorage, nextMatches);
+    if (!saveResult.ok) {
+      setInfoMessage(saveResult.error);
+    }
+  }, []);
 
   function applySetupFromMatch(match: LocalMatchSummary) {
     setSelectedCharacters(match.roster_character_ids);
@@ -108,6 +456,7 @@ export default function Home() {
       if (previous.includes(characterId)) {
         return previous.filter((id) => id !== characterId);
       }
+
       return [...previous, characterId];
     });
   }
@@ -115,51 +464,100 @@ export default function Home() {
   function generateSeed() {
     const generatedSeed = createBrowserUuid();
     if (!generatedSeed) {
-      setInfoMessage('No fue posible generar seed automaticamente en este navegador.');
+      setInfoMessage('No fue posible generar seed automatica en este navegador.');
       return;
     }
 
     setSeed(generatedSeed.slice(0, 8));
   }
 
-  function onStartMatch() {
+  async function onStartMatch() {
     if (!setupValidation.is_valid) {
       setInfoMessage('Config invalida. Revisa el roster antes de iniciar.');
       return;
     }
 
-    const newMatchId = createBrowserUuid();
-    if (!newMatchId) {
-      setInfoMessage('No fue posible crear el identificador de la partida.');
-      return;
+    setIsBusy(true);
+    setInfoMessage(null);
+
+    try {
+      const createResponse = await requestJson<CreateMatchResponse>('/api/matches', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          roster_character_ids: selectedCharacters,
+          settings: {
+            surprise_level: surpriseLevel,
+            event_profile: eventProfile,
+            simulation_speed: simulationSpeed,
+            seed: seed.trim() === '' ? null : seed.trim()
+          }
+        })
+      });
+
+      await requestJson<StartMatchResponse>(`/api/matches/${createResponse.match_id}/start`, {
+        method: 'POST'
+      });
+
+      const state = await requestJson<GetMatchStateResponse>(
+        `/api/matches/${createResponse.match_id}`
+      );
+
+      const runtimeState: SimulationRuntime = {
+        match_id: createResponse.match_id,
+        phase: state.phase,
+        cycle_phase: state.cycle_phase,
+        turn_number: state.turn_number,
+        tension_level: state.tension_level,
+        settings: state.settings,
+        participants: state.participants,
+        feed: feedFromSnapshot(state),
+        winner_id: null
+      };
+
+      setRuntime(runtimeState);
+      setPlaybackSpeed(simulationSpeed);
+      setFilterCharacterId('all');
+      setFilterEventType('all');
+      setLatestFeedEventId(null);
+
+      const nowIso = new Date().toISOString();
+      const newSummaryBase = createLocalMatchFromSetup(
+        {
+          roster_character_ids: selectedCharacters,
+          seed: seed.trim() === '' ? null : seed.trim(),
+          simulation_speed: simulationSpeed,
+          event_profile: eventProfile,
+          surprise_level: surpriseLevel
+        },
+        nowIso,
+        createResponse.match_id
+      );
+
+      const newSummary: LocalMatchSummary = {
+        ...newSummaryBase,
+        cycle_phase: state.cycle_phase,
+        turn_number: state.turn_number,
+        alive_count: countAlive(state.participants),
+        updated_at: nowIso
+      };
+
+      const nextMatches = [newSummary, ...localMatches.filter((match) => match.id !== newSummary.id)];
+      persistLocalMatches(nextMatches);
+      setOpenedMatchId(newSummary.id);
+      setInfoMessage(`Simulacion iniciada (${shortId(createResponse.match_id)}).`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'No fue posible iniciar la simulacion.';
+      setInfoMessage(errorMessage);
+      setPlaybackSpeed('pause');
+    } finally {
+      setIsBusy(false);
     }
-
-    const nowIso = new Date().toISOString();
-    const newMatch = createLocalMatchFromSetup(
-      {
-        roster_character_ids: selectedCharacters,
-        seed: seed.trim() === '' ? null : seed.trim(),
-        simulation_speed: simulationSpeed,
-        event_profile: eventProfile,
-        surprise_level: surpriseLevel
-      },
-      nowIso,
-      newMatchId
-    );
-
-    const nextMatches = [newMatch, ...localMatches];
-    const saveResult = saveLocalMatchesToStorage(window.localStorage, nextMatches);
-    if (!saveResult.ok) {
-      setInfoMessage(saveResult.error);
-      return;
-    }
-
-    setLocalMatches(nextMatches);
-    setOpenedMatchId(newMatch.id);
-    setInfoMessage(`Partida creada (${newMatch.id.slice(0, 8)}).`);
   }
 
-  function onOpenMatch(matchId: string) {
+  async function onOpenMatch(matchId: string) {
     const match = localMatches.find((item) => item.id === matchId);
     if (!match) {
       setInfoMessage('No se encontro la partida seleccionada.');
@@ -168,192 +566,559 @@ export default function Home() {
 
     setOpenedMatchId(match.id);
     applySetupFromMatch(match);
-    setInfoMessage(`Partida abierta (${match.id.slice(0, 8)}).`);
+    setPlaybackSpeed('pause');
+    setIsBusy(true);
+
+    try {
+      const state = await requestJson<GetMatchStateResponse>(`/api/matches/${match.id}`);
+      setRuntime({
+        match_id: match.id,
+        phase: state.phase,
+        cycle_phase: state.cycle_phase,
+        turn_number: state.turn_number,
+        tension_level: state.tension_level,
+        settings: state.settings,
+        participants: state.participants,
+        feed: feedFromSnapshot(state),
+        winner_id: state.phase === 'finished' ? state.participants.find((p) => p.status !== 'eliminated')?.id ?? null : null
+      });
+      setInfoMessage(`Partida abierta en vivo (${shortId(match.id)}).`);
+    } catch {
+      setRuntime(null);
+      setInfoMessage(`Setup cargado (${shortId(match.id)}). Simulacion en vivo no disponible para ese id.`);
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  const onAdvanceStep = useCallback(async () => {
+    if (!runtime || runtime.phase !== 'running' || isBusy) {
+      return;
+    }
+
+    setIsBusy(true);
+
+    try {
+      const advance = await requestJson<AdvanceTurnResponse>(
+        `/api/matches/${runtime.match_id}/turns/advance`,
+        {
+          method: 'POST'
+        }
+      );
+      const state = await requestJson<GetMatchStateResponse>(`/api/matches/${runtime.match_id}`);
+      const event = feedFromAdvance(advance, state.participants);
+      const nextFeed = [event, ...runtime.feed].slice(0, 100);
+
+      const nextRuntime: SimulationRuntime = {
+        ...runtime,
+        phase: state.phase,
+        cycle_phase: state.cycle_phase,
+        turn_number: state.turn_number,
+        tension_level: state.tension_level,
+        settings: state.settings,
+        participants: state.participants,
+        feed: nextFeed,
+        winner_id: advance.winner_id
+      };
+
+      setRuntime(nextRuntime);
+      setLatestFeedEventId(event.id);
+
+      const summary = localMatches.find((match) => match.id === runtime.match_id);
+      if (summary) {
+        const nowIso = new Date().toISOString();
+        const updatedSummary: LocalMatchSummary = {
+          ...summary,
+          cycle_phase: state.cycle_phase,
+          turn_number: state.turn_number,
+          alive_count: countAlive(state.participants),
+          updated_at: nowIso
+        };
+        const nextMatches = [
+          updatedSummary,
+          ...localMatches.filter((match) => match.id !== updatedSummary.id)
+        ];
+        persistLocalMatches(nextMatches);
+      }
+
+      if (advance.finished) {
+        setPlaybackSpeed('pause');
+        const winnerName =
+          state.participants.find((participant) => participant.id === advance.winner_id)?.character_id ??
+          null;
+        setInfoMessage(
+          winnerName
+            ? `Partida finalizada. Ganador: ${characterName(winnerName)}.`
+            : 'Partida finalizada.'
+        );
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'No fue posible avanzar la simulacion.';
+      setPlaybackSpeed('pause');
+      setInfoMessage(errorMessage);
+    } finally {
+      setIsBusy(false);
+    }
+  }, [isBusy, localMatches, persistLocalMatches, runtime]);
+
+  useEffect(() => {
+    if (!runtime || runtime.phase !== 'running' || playbackSpeed === 'pause' || isBusy) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      void onAdvanceStep();
+    }, SPEED_INTERVAL_MS[playbackSpeed]);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isBusy, onAdvanceStep, playbackSpeed, runtime]);
+
+  async function onShareSnapshot() {
+    if (!runtime) {
+      setInfoMessage('Inicia una simulacion para compartir el estado.');
+      return;
+    }
+
+    const shareText = `Hunger Games ${shortId(runtime.match_id)} | turno ${runtime.turn_number} | fase ${runtime.cycle_phase} | vivos ${countAlive(runtime.participants)}`;
+
+    try {
+      if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+        setInfoMessage('Clipboard no disponible en este navegador.');
+        return;
+      }
+
+      await navigator.clipboard.writeText(shareText);
+      setInfoMessage('Resumen de simulacion copiado para compartir.');
+    } catch {
+      setInfoMessage('No fue posible copiar el resumen al portapapeles.');
+    }
+  }
+
+  function onSaveSnapshot() {
+    if (!runtime) {
+      setInfoMessage('No hay simulacion activa para guardar.');
+      return;
+    }
+
+    const existing = localMatches.find((match) => match.id === runtime.match_id);
+    const nowIso = new Date().toISOString();
+    const summary: LocalMatchSummary = {
+      id: runtime.match_id,
+      created_at: existing?.created_at ?? nowIso,
+      updated_at: nowIso,
+      roster_character_ids: runtime.participants.map((participant) => participant.character_id),
+      cycle_phase: runtime.cycle_phase,
+      turn_number: runtime.turn_number,
+      alive_count: countAlive(runtime.participants),
+      total_participants: runtime.participants.length,
+      settings: runtime.settings
+    };
+
+    const nextMatches = [summary, ...localMatches.filter((match) => match.id !== summary.id)];
+    persistLocalMatches(nextMatches);
+    setOpenedMatchId(summary.id);
+    setInfoMessage(`Progreso guardado (${shortId(summary.id)}).`);
   }
 
   return (
-    <main
-      style={{
-        maxWidth: 980,
-        margin: '0 auto',
-        padding: '24px 16px 48px',
-        fontFamily: 'ui-sans-serif, system-ui'
-      }}
-    >
-      <header style={{ marginBottom: 24 }}>
-        <h1 style={{ marginBottom: 8 }}>Hunger Games Simulator</h1>
-        <p style={{ margin: 0, color: '#334155' }}>
-          Fase actual: <strong>{openedMatch?.cycle_phase ?? 'setup'}</strong>
-        </p>
-        <div
-          aria-label="barra de tension"
-          style={{
-            marginTop: 8,
-            height: 10,
-            borderRadius: 999,
-            backgroundColor: '#e2e8f0',
-            overflow: 'hidden'
-          }}
-        >
-          <div
-            style={{
-              width: `${tensionPreview}%`,
-              height: '100%',
-              backgroundColor: tensionPreview > 70 ? '#dc2626' : '#0ea5e9'
-            }}
-          />
-        </div>
-      </header>
-
-      <section style={{ marginBottom: 28 }}>
-        <h2 style={{ marginBottom: 8 }}>Setup de partida</h2>
-        <p style={{ marginTop: 0, color: '#475569' }}>
-          Selecciona roster, seed y ritmo antes de iniciar.
-        </p>
-
-        <div style={{ display: 'grid', gap: 6, marginBottom: 12 }}>
-          {CHARACTER_OPTIONS.map((character) => (
-            <label key={character.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input
-                type="checkbox"
-                checked={selectedCharacters.includes(character.id)}
-                onChange={() => toggleCharacter(character.id)}
-              />
-              {character.name}
-            </label>
-          ))}
-        </div>
-
-        <div style={{ display: 'grid', gap: 10, maxWidth: 420 }}>
-          <label style={{ display: 'grid', gap: 4 }}>
-            Seed (opcional)
-            <div style={{ display: 'flex', gap: 8 }}>
-              <input
-                value={seed}
-                onChange={(event) => setSeed(event.target.value)}
-                placeholder="manual o aleatoria"
-                style={{ flex: 1 }}
-              />
-              <button type="button" onClick={generateSeed}>
-                Aleatoria
-              </button>
-            </div>
-          </label>
-
-          <label style={{ display: 'grid', gap: 4 }}>
-            Ritmo
-            <select
-              value={simulationSpeed}
-              onChange={(event) => setSimulationSpeed(event.target.value as '1x' | '2x' | '4x')}
-            >
-              <option value="1x">1x</option>
-              <option value="2x">2x</option>
-              <option value="4x">4x</option>
-            </select>
-          </label>
-
-          <button
-            type="button"
-            onClick={() => setShowAdvanced((current) => !current)}
-            style={{ justifySelf: 'start' }}
-          >
-            {showAdvanced ? 'Ocultar opciones avanzadas' : 'Mostrar opciones avanzadas'}
-          </button>
-
-          {showAdvanced ? (
-            <>
-              <label style={{ display: 'grid', gap: 4 }}>
-                Perfil de eventos
-                <select
-                  value={eventProfile}
-                  onChange={(event) =>
-                    setEventProfile(event.target.value as 'balanced' | 'aggressive' | 'chaotic')
-                  }
-                >
-                  <option value="balanced">Balanced</option>
-                  <option value="aggressive">Aggressive</option>
-                  <option value="chaotic">Chaotic</option>
-                </select>
-              </label>
-
-              <label style={{ display: 'grid', gap: 4 }}>
-                Nivel de sorpresa
-                <select
-                  value={surpriseLevel}
-                  onChange={(event) =>
-                    setSurpriseLevel(event.target.value as 'low' | 'normal' | 'high')
-                  }
-                >
-                  <option value="low">Low</option>
-                  <option value="normal">Normal</option>
-                  <option value="high">High</option>
-                </select>
-              </label>
-            </>
-          ) : null}
-        </div>
-
-        <div style={{ marginTop: 14, padding: 10, border: '1px solid #cbd5e1', borderRadius: 8 }}>
-          <strong>Resumen</strong>
-          <p style={{ margin: '6px 0' }}>
-            Roster: {selectedCharacters.length} personajes | Seed:{' '}
-            {seed.trim() === '' ? 'aleatoria al iniciar' : seed.trim()} | Ritmo: {simulationSpeed}
+    <main className={styles.page}>
+      <div className={styles.shell}>
+        <header className={styles.hero}>
+          <div className={styles.heroTop}>
+            <h1 className={styles.title}>Hunger Games Simulator</h1>
+            <strong>{runtime?.phase === 'finished' ? 'Partida cerrada' : 'Simulacion en vivo'}</strong>
+          </div>
+          <p className={styles.heroMeta}>
+            Fase actual: <strong>{phaseLabel(currentPhase)}</strong>
           </p>
-          {setupValidation.issues.length > 0 ? (
-            <ul style={{ marginTop: 4, marginBottom: 8 }}>
-              {setupValidation.issues.map((issue) => (
-                <li key={issue}>{issue}</li>
-              ))}
-            </ul>
-          ) : (
-            <p style={{ margin: '6px 0', color: '#166534' }}>Configuracion valida.</p>
-          )}
 
-          <button type="button" disabled={!setupValidation.is_valid} onClick={onStartMatch}>
-            Iniciar partida nueva
-          </button>
-          <button type="button" onClick={resetSetupToDefaults} style={{ marginLeft: 8 }}>
-            Nuevo setup
-          </button>
-          {infoMessage ? <p style={{ marginBottom: 0 }}>{infoMessage}</p> : null}
-        </div>
-      </section>
+          <div className={styles.kpis}>
+            <div className={styles.kpi}>
+              <span className={styles.kpiLabel}>Turno</span>
+              <div className={styles.kpiValue}>{currentTurn}</div>
+            </div>
+            <div className={styles.kpi}>
+              <span className={styles.kpiLabel}>Vivos</span>
+              <div className={styles.kpiValue}>{aliveCount}</div>
+            </div>
+            <div className={styles.kpi}>
+              <span className={styles.kpiLabel}>Eliminados</span>
+              <div className={styles.kpiValue}>{eliminatedCount}</div>
+            </div>
+            <div className={styles.kpi}>
+              <span className={styles.kpiLabel}>Ritmo</span>
+              <div className={styles.kpiValue}>{playbackSpeed === 'pause' ? 'Pausa' : playbackSpeed}</div>
+            </div>
+          </div>
 
-      <section>
-        <h2 style={{ marginBottom: 8 }}>Partidas locales</h2>
-        {localMatches.length === 0 ? (
-          <p style={{ color: '#64748b' }}>No hay partidas guardadas en este navegador.</p>
-        ) : (
-          <ul style={{ display: 'grid', gap: 10, padding: 0 }}>
-            {localMatches.map((match) => (
-              <li
-                key={match.id}
-                style={{
-                  listStyle: 'none',
-                  border: '1px solid #e2e8f0',
-                  borderRadius: 8,
-                  padding: 10
-                }}
-              >
-                <p style={{ margin: '0 0 6px' }}>
-                  <strong>{match.id.slice(0, 8)}</strong> | {match.cycle_phase} | turno{' '}
-                  {match.turn_number}
-                </p>
-                <p style={{ margin: '0 0 8px', color: '#475569' }}>
-                  Vivos: {match.alive_count}/{match.total_participants} | Seed:{' '}
-                  {match.settings.seed ?? 'sin seed'}
-                </p>
+          <div className={styles.tension} aria-label="barra de tension">
+            <strong>Tension {Math.round(tensionValue)}%</strong>
+            <div className={styles.tensionTrack}>
+              <div className={styles.tensionBar} style={{ width: `${Math.min(100, tensionValue)}%` }} />
+            </div>
+          </div>
+        </header>
+
+        <div className={styles.columns}>
+          <section className={styles.card}>
+            <h2 className={styles.cardTitle}>Setup de partida</h2>
+            <p className={styles.cardHint}>Define roster, seed y perfil antes de iniciar.</p>
+
+            <div className={styles.setupGrid}>
+              <div className={styles.rosterGrid}>
+                {CHARACTER_OPTIONS.map((character) => (
+                  <label key={character.id} className={styles.characterToggle}>
+                    <input
+                      type="checkbox"
+                      checked={selectedCharacters.includes(character.id)}
+                      onChange={() => toggleCharacter(character.id)}
+                    />
+                    {character.name}
+                  </label>
+                ))}
+              </div>
+
+              <div className={styles.controlsGrid}>
+                <label className={styles.controlLabel}>
+                  Seed (opcional)
+                  <div className={styles.inlineControls}>
+                    <input
+                      className={styles.input}
+                      value={seed}
+                      onChange={(event) => setSeed(event.target.value)}
+                      placeholder="manual o aleatoria"
+                    />
+                    <button className={styles.button} type="button" onClick={generateSeed}>
+                      Aleatoria
+                    </button>
+                  </div>
+                </label>
+
+                <label className={styles.controlLabel}>
+                  Ritmo inicial
+                  <select
+                    className={styles.select}
+                    value={simulationSpeed}
+                    onChange={(event) => setSimulationSpeed(event.target.value as SimulationSpeed)}
+                  >
+                    <option value="1x">1x</option>
+                    <option value="2x">2x</option>
+                    <option value="4x">4x</option>
+                  </select>
+                </label>
+
+                <button
+                  className={`${styles.button} ${styles.buttonGhost}`}
+                  type="button"
+                  onClick={() => setShowAdvanced((current) => !current)}
+                >
+                  {showAdvanced ? 'Ocultar opciones avanzadas' : 'Mostrar opciones avanzadas'}
+                </button>
+
+                {showAdvanced ? (
+                  <>
+                    <label className={styles.controlLabel}>
+                      Perfil de eventos
+                      <select
+                        className={styles.select}
+                        value={eventProfile}
+                        onChange={(event) =>
+                          setEventProfile(event.target.value as 'balanced' | 'aggressive' | 'chaotic')
+                        }
+                      >
+                        <option value="balanced">Balanced</option>
+                        <option value="aggressive">Aggressive</option>
+                        <option value="chaotic">Chaotic</option>
+                      </select>
+                    </label>
+
+                    <label className={styles.controlLabel}>
+                      Nivel de sorpresa
+                      <select
+                        className={styles.select}
+                        value={surpriseLevel}
+                        onChange={(event) =>
+                          setSurpriseLevel(event.target.value as 'low' | 'normal' | 'high')
+                        }
+                      >
+                        <option value="low">Low</option>
+                        <option value="normal">Normal</option>
+                        <option value="high">High</option>
+                      </select>
+                    </label>
+                  </>
+                ) : null}
+              </div>
+
+              <div>
+                <strong>
+                  Roster: {selectedCharacters.length} | Seed:{' '}
+                  {seed.trim() === '' ? 'aleatoria al iniciar' : seed.trim()}
+                </strong>
+                {setupValidation.issues.length > 0 ? (
+                  <ul>
+                    {setupValidation.issues.map((issue) => (
+                      <li key={issue}>{issue}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>Configuracion valida para iniciar.</p>
+                )}
+
+                <div className={styles.inlineControls}>
+                  <button
+                    className={styles.button}
+                    type="button"
+                    disabled={!setupValidation.is_valid || isBusy}
+                    onClick={() => {
+                      void onStartMatch();
+                    }}
+                  >
+                    Iniciar simulacion
+                  </button>
+                  <button className={styles.button} type="button" onClick={resetSetupToDefaults}>
+                    Nuevo setup
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className={styles.eventShell}>
+            <article className={styles.card}>
+              <h2 className={styles.cardTitle}>Feed narrativo</h2>
+              <p className={styles.cardHint}>
+                Cada evento resume quien, que y su impacto directo en 1-2 lineas.
+              </p>
+
+              <div className={styles.speedControls}>
+                {(['1x', '2x', '4x'] as SimulationSpeed[]).map((speed) => (
+                  <button
+                    key={speed}
+                    type="button"
+                    className={`${styles.speedButton} ${
+                      playbackSpeed === speed ? styles.speedButtonActive : ''
+                    }`}
+                    onClick={() => {
+                      setSimulationSpeed(speed);
+                      setPlaybackSpeed(speed);
+                    }}
+                    disabled={!runtime || runtime.phase !== 'running'}
+                  >
+                    {speed}
+                  </button>
+                ))}
                 <button
                   type="button"
-                  onClick={() => onOpenMatch(match.id)}
+                  className={`${styles.speedButton} ${
+                    playbackSpeed === 'pause' ? styles.speedButtonActive : ''
+                  }`}
+                  onClick={() => setPlaybackSpeed('pause')}
+                  disabled={!runtime || runtime.phase !== 'running'}
                 >
-                  Abrir partida y cargar setup
+                  Pausa
                 </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+                <button
+                  type="button"
+                  className={styles.speedButton}
+                  onClick={() => {
+                    setPlaybackSpeed('pause');
+                    void onAdvanceStep();
+                  }}
+                  disabled={!runtime || runtime.phase !== 'running' || isBusy}
+                >
+                  Paso
+                </button>
+                <button
+                  type="button"
+                  className={styles.speedButton}
+                  onClick={onSaveSnapshot}
+                  disabled={!runtime || isBusy}
+                >
+                  Guardar
+                </button>
+                <button
+                  type="button"
+                  className={styles.speedButton}
+                  onClick={() => {
+                    void onShareSnapshot();
+                  }}
+                  disabled={!runtime}
+                >
+                  Compartir
+                </button>
+              </div>
+
+              <div className={styles.feedFilters}>
+                <label className={styles.controlLabel}>
+                  Filtro por personaje
+                  <select
+                    className={styles.select}
+                    value={filterCharacterId}
+                    onChange={(event) => setFilterCharacterId(event.target.value)}
+                  >
+                    <option value="all">Todos</option>
+                    {characterFilterOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className={styles.controlLabel}>
+                  Filtro por tipo
+                  <select
+                    className={styles.select}
+                    value={filterEventType}
+                    onChange={(event) =>
+                      setFilterEventType(event.target.value as 'all' | EventType)
+                    }
+                  >
+                    <option value="all">Todos</option>
+                    {(Object.keys(EVENT_TYPE_LABEL) as EventType[]).map((eventType) => (
+                      <option key={eventType} value={eventType}>
+                        {EVENT_TYPE_LABEL[eventType]}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              {filteredFeed.length === 0 ? (
+                <p>
+                  {runtime
+                    ? 'Aun no hay eventos que coincidan con los filtros activos.'
+                    : 'Inicia una simulacion para ver el feed en vivo.'}
+                </p>
+              ) : (
+                <ul className={styles.feedList}>
+                  {filteredFeed.map((event) => (
+                    <li
+                      key={event.id}
+                      className={`${styles.feedItem} ${
+                        latestFeedEventId === event.id ? styles.feedItemNew : ''
+                      }`}
+                    >
+                      <p className={styles.feedMeta}>
+                        <span>
+                          Turno {event.turn_number} · {phaseLabel(event.phase)}
+                        </span>
+                        <span>{EVENT_TYPE_LABEL[event.type]}</span>
+                      </p>
+                      <p className={styles.feedHeadline}>{event.headline}</p>
+                      <p className={styles.feedImpact}>{event.impact}</p>
+                      <div className={styles.tagRow}>
+                        {event.character_ids.length === 0 ? (
+                          <span className={styles.tag}>Sin participantes trazables</span>
+                        ) : (
+                          event.character_ids.map((characterId) => (
+                            <span key={`${event.id}-${characterId}`} className={styles.tag}>
+                              {characterName(characterId)}
+                            </span>
+                          ))
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </article>
+
+            <aside className={styles.sideGrid}>
+              <section className={styles.card}>
+                <h3 className={styles.cardTitle}>Participantes</h3>
+                <ul className={styles.participantList}>
+                  {participantStatusList.length === 0 ? (
+                    <li className={styles.participantItem}>Sin simulacion activa.</li>
+                  ) : (
+                    participantStatusList.map((participant) => {
+                      const statusClassName =
+                        participant.status === 'alive'
+                          ? styles.statusAlive
+                          : participant.status === 'injured'
+                            ? styles.statusInjured
+                            : styles.statusEliminated;
+
+                      return (
+                        <li key={participant.id} className={styles.participantItem}>
+                          <strong>{characterName(participant.character_id)}</strong>
+                          <div>
+                            <span className={`${styles.status} ${statusClassName}`}>
+                              {statusLabel(participant.status)}
+                            </span>{' '}
+                            · Salud {participant.current_health}
+                          </div>
+                        </li>
+                      );
+                    })
+                  )}
+                </ul>
+              </section>
+
+              <section className={styles.card}>
+                <h3 className={styles.cardTitle}>Relaciones destacadas</h3>
+                <ul className={styles.relationsList}>
+                  {relationHighlights.length === 0 ? (
+                    <li className={styles.relationItem}>Todavia no hay relaciones significativas.</li>
+                  ) : (
+                    relationHighlights.map((relation) => (
+                      <li key={`${relation.pair[0]}-${relation.pair[1]}`} className={styles.relationItem}>
+                        <strong>
+                          {characterName(relation.pair[0])} · {characterName(relation.pair[1])}
+                        </strong>
+                        <div
+                          className={
+                            relation.score >= 0 ? styles.relationPositive : styles.relationNegative
+                          }
+                        >
+                          {relationTone(relation.score)}
+                        </div>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </section>
+
+              <section className={styles.card}>
+                <h3 className={styles.cardTitle}>Partidas locales</h3>
+                {localMatches.length === 0 ? (
+                  <p>No hay partidas guardadas.</p>
+                ) : (
+                  <ul className={styles.matchList}>
+                    {localMatches.map((match) => (
+                      <li key={match.id} className={styles.matchItem}>
+                        <p>
+                          <strong>{shortId(match.id)}</strong> · {phaseLabel(match.cycle_phase)} · turno{' '}
+                          {match.turn_number}
+                        </p>
+                        <p>
+                          Vivos: {match.alive_count}/{match.total_participants} · Seed:{' '}
+                          {match.settings.seed ?? 'sin seed'}
+                        </p>
+                        <button
+                          className={styles.button}
+                          type="button"
+                          onClick={() => {
+                            void onOpenMatch(match.id);
+                          }}
+                        >
+                          Abrir setup
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </aside>
+          </section>
+        </div>
+
+        {infoMessage ? <p className={styles.info}>{infoMessage}</p> : null}
+      </div>
     </main>
   );
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/specs/plans/stories/05-US-005A.md
+++ b/specs/plans/stories/05-US-005A.md
@@ -1,6 +1,6 @@
 # 05 - US-005A - UX simulacion en vivo
 
-- Estado: `TODO`
+- Estado: `DONE`
 - Priority: `P0`
 - Dependencies: `US-004`
 
@@ -17,6 +17,6 @@ As a jugador, I want feed + estados + controles, so that pueda seguir la histori
 - `specs/L1-functional.md`
 
 ## Implementation checklist
-- Implementar pantalla de simulacion con header de estado.
-- Implementar feed cronologico + animacion breve + filtros.
-- Implementar panel lateral de participantes y relaciones destacadas.
+- [x] Implementar pantalla de simulacion con header de estado.
+- [x] Implementar feed cronologico + animacion breve + filtros.
+- [x] Implementar panel lateral de participantes y relaciones destacadas.


### PR DESCRIPTION
## Resumen
- implementa la pantalla de simulación en vivo con header de estado (vivos/eliminados/turno/fase/tensión)
- agrega feed narrativo cronológico con animación breve, formato quién/qué/impacto y filtros por personaje/tipo
- incorpora controles de ritmo `1x/2x/4x/pausa/paso` manteniendo contexto visual
- añade panel lateral con estados de participantes y relaciones destacadas
- actualiza trazabilidad de la historia `specs/plans/stories/05-US-005A.md` a `DONE`

## Validación
- `npm run lint`
- `npm run test:unit`
- `npm run test:coverage`
- `npm run validate`

## Cobertura
- líneas: 95.93%
- branches: 94.11%
- funciones: 100%
- statements: 95.93%

Closes #7
