### PR TITLE
fix: corregir layout principal del dashboard (issue #32)

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -19,7 +19,7 @@
 }
 
 .shell {
-  max-width: 1180px;
+  max-width: 1360px;
   margin: 0 auto;
   display: grid;
   gap: 16px;
@@ -104,6 +104,10 @@
   display: grid;
   gap: 14px;
   grid-template-columns: minmax(0, 1fr);
+}
+
+.columns > * {
+  min-width: 0;
 }
 
 .card {
@@ -302,6 +306,7 @@
 .sideGrid {
   display: grid;
   gap: 14px;
+  align-content: start;
 }
 
 .participantList,
@@ -357,12 +362,16 @@
 
 @media (min-width: 980px) {
   .columns {
-    grid-template-columns: 360px minmax(0, 1fr);
+    grid-template-columns: minmax(300px, 340px) minmax(0, 1fr);
     align-items: start;
   }
 
+  .columns > .eventShell:only-child {
+    grid-column: 1 / -1;
+  }
+
   .eventShell {
-    grid-template-columns: minmax(0, 1fr) 300px;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
     align-items: start;
   }
 }

--- a/specs/L3-ux.md
+++ b/specs/L3-ux.md
@@ -41,3 +41,10 @@ Interfaz de "reality show de supervivencia": rápida, clara y dramática.
 - Colores semánticos consistentes para estado y riesgo.
 - Eventos sorpresa y giros deben tener tratamiento visual distintivo.
 - Contraste suficiente para lectura prolongada en desktop y móvil.
+
+## Reglas de layout desktop
+- La vista principal usa contenedor centrado con `max-width` para evitar vacío lateral desproporcionado.
+- Si `Setup` no está visible (simulación activa), el bloque `Feed + panel lateral` debe ocupar el ancho completo disponible.
+- El `Feed narrativo` siempre conserva prioridad visual frente a `Setup` y no puede quedar cubierto por paneles laterales.
+- Los controles de ritmo (`1x/2x/4x/pausa/paso`) se mantienen visibles y clicables en breakpoints desktop.
+- `Participantes`, `Relaciones destacadas` y `Partidas locales` mantienen orden vertical estable dentro del panel lateral.


### PR DESCRIPTION
## Resumen
- corrige la composición desktop cuando Setup no está visible para que Feed + panel lateral usen todo el ancho
- ajusta jerarquía visual: Setup pierde peso relativo, Feed mantiene foco
- evita desbordes/solapamientos con min-width: 0 y columnas más estables
- documenta reglas de layout desktop en UX spec

## Cambios
- app/page.module.css
  - shell con max-width mayor y centrado
  - regla :only-child para que eventShell ocupe ambas columnas cuando no hay Setup
  - ajuste de columnas desktop (columns y eventShell)
  - mejoras de estabilidad en panel lateral
- specs/L3-ux.md
  - nuevas reglas explícitas de layout desktop para prevenir regresión

## Validación
- npm run lint
- npm run test:unit
- npm run test:coverage
- npm run validate

Closes #32
