### PR TITLE
feat: US-006A final screen and replay controls

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -175,6 +175,54 @@
   color: var(--muted);
 }
 
+.finalCard {
+  background: linear-gradient(145deg, #fff7ea, #fffef9);
+}
+
+.finalWinner {
+  border: 1px solid #e3b165;
+  border-radius: 12px;
+  padding: 10px;
+  display: grid;
+  gap: 2px;
+  margin-bottom: 12px;
+  background: #fff6de;
+}
+
+.finalWinner span {
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.78rem;
+}
+
+.finalWinner strong {
+  font-size: 1.25rem;
+}
+
+.finalGrid {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.finalSubtitle {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.finalList {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+}
+
+.replayGrid {
+  display: grid;
+  gap: 8px;
+}
+
 .setupGrid {
   display: grid;
   gap: 14px;
@@ -421,6 +469,14 @@
   .eventShell {
     grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
     align-items: start;
+  }
+
+  .finalGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .replayGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/lib/local-runtime.ts
+++ b/lib/local-runtime.ts
@@ -20,6 +20,7 @@ export type RuntimeFeedEvent = {
   headline: string;
   impact: string;
   character_ids: string[];
+  eliminated_character_ids?: string[];
   created_at: string;
 };
 
@@ -99,6 +100,7 @@ const localRuntimeSnapshotSchema = z
           headline: nonEmptyStringSchema,
           impact: nonEmptyStringSchema,
           character_ids: z.array(nonEmptyStringSchema),
+          eliminated_character_ids: z.array(nonEmptyStringSchema).optional(),
           created_at: z.string().datetime()
         })
         .strict()

--- a/tests/local-runtime.test.ts
+++ b/tests/local-runtime.test.ts
@@ -165,6 +165,33 @@ describe('local runtime storage', () => {
     });
   });
 
+  it('loads runtime with replay elimination trace metadata', () => {
+    const runtime: LocalRuntimeSnapshot = {
+      ...buildRuntime(),
+      feed: [
+        {
+          ...buildRuntime().feed[0],
+          eliminated_character_ids: ['char-02']
+        }
+      ]
+    };
+    let persisted: string | null = null;
+    const storage = {
+      setItem(_key: string, value: string) {
+        persisted = value;
+      },
+      getItem() {
+        return persisted;
+      }
+    };
+
+    saveLocalRuntimeToStorage(storage, runtime);
+    expect(loadLocalRuntimeFromStorage(storage)).toEqual({
+      runtime,
+      error: null
+    });
+  });
+
   it('returns read error when storage throws', () => {
     const storage = {
       getItem() {


### PR DESCRIPTION
## Summary
- add final match view with winner, key moments and elimination order
- add replay CTAs for same/new seed and same/new roster
- persist replay elimination trace metadata in local runtime snapshots

## Validation
- npm run lint
- npm run test:unit
- npm run test:coverage
- npm run validate

Closes #9