### PR TITLE
test: harden unit tests for snapshot validation and resume safety

### DIFF
--- a/lib/simulation-state.ts
+++ b/lib/simulation-state.ts
@@ -227,9 +227,16 @@ export function canResumeFromLocalStorage(raw: string | null): boolean {
 
   try {
     const parsed = JSON.parse(raw) as Partial<MatchState>;
-    return (
-      typeof parsed.id === 'string' &&
+    const hasValidId = typeof parsed.id === 'string' && parsed.id.trim().length > 0;
+    const hasValidTurn =
       typeof parsed.turn === 'number' &&
+      Number.isInteger(parsed.turn) &&
+      Number.isFinite(parsed.turn) &&
+      parsed.turn >= 0;
+
+    return (
+      hasValidId &&
+      hasValidTurn &&
       typeof parsed.active === 'boolean'
     );
   } catch {

--- a/tests/matches-resume-route.test.ts
+++ b/tests/matches-resume-route.test.ts
@@ -128,6 +128,20 @@ describe('POST /api/matches/resume', () => {
 
     expect(lastResponse?.status).toBe(429);
     const body = await lastResponse?.json();
-    expect(body.error.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(body).toEqual({
+      error: {
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: 'Rate limit exceeded for resume_match.',
+        details: {
+          issues: [
+            {
+              path: ['request'],
+              code: 'rate_limit_exceeded',
+              message: expect.stringMatching(/^Retry after \d+ seconds\.$/)
+            }
+          ]
+        }
+      }
+    });
   });
 });

--- a/tests/matches-route.test.ts
+++ b/tests/matches-route.test.ts
@@ -154,6 +154,20 @@ describe('POST /api/matches', () => {
 
     expect(lastResponse?.status).toBe(429);
     const body = await lastResponse?.json();
-    expect(body.error.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(body).toEqual({
+      error: {
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: 'Rate limit exceeded for create_match.',
+        details: {
+          issues: [
+            {
+              path: ['request'],
+              code: 'rate_limit_exceeded',
+              message: expect.stringMatching(/^Retry after \d+ seconds\.$/)
+            }
+          ]
+        }
+      }
+    });
   });
 });

--- a/tests/simulation-state.test.ts
+++ b/tests/simulation-state.test.ts
@@ -48,6 +48,42 @@ describe('canResumeFromLocalStorage', () => {
       )
     ).toBe(true);
   });
+
+  it('returns false for non-finite or non-integer turn values', () => {
+    expect(
+      canResumeFromLocalStorage(
+        JSON.stringify({ id: 'm1', turn: Number.NaN, active: true })
+      )
+    ).toBe(false);
+    expect(
+      canResumeFromLocalStorage(
+        JSON.stringify({ id: 'm1', turn: Number.POSITIVE_INFINITY, active: true })
+      )
+    ).toBe(false);
+    expect(
+      canResumeFromLocalStorage(
+        JSON.stringify({ id: 'm1', turn: 1.5, active: true })
+      )
+    ).toBe(false);
+    expect(
+      canResumeFromLocalStorage(
+        JSON.stringify({ id: 'm1', turn: -1, active: true })
+      )
+    ).toBe(false);
+  });
+
+  it('returns false for blank id values', () => {
+    expect(
+      canResumeFromLocalStorage(
+        JSON.stringify({ id: '', turn: 1, active: true })
+      )
+    ).toBe(false);
+    expect(
+      canResumeFromLocalStorage(
+        JSON.stringify({ id: '   ', turn: 1, active: true })
+      )
+    ).toBe(false);
+  });
 });
 
 describe('seeded RNG reproducibility', () => {

--- a/tests/snapshot-request.test.ts
+++ b/tests/snapshot-request.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_SNAPSHOT_REQUEST_BYTES,
+  validateSnapshotEnvelopeFromRawBody
+} from '@/lib/api/snapshot-request';
+import { buildSnapshotChecksum } from '@/lib/domain/snapshot-checksum';
+import { RULESET_VERSION, SNAPSHOT_VERSION, type MatchSnapshot } from '@/lib/domain/types';
+
+function buildSnapshot(): MatchSnapshot {
+  return {
+    snapshot_version: SNAPSHOT_VERSION,
+    ruleset_version: RULESET_VERSION,
+    match: {
+      id: 'match-1',
+      seed: 'seed-1',
+      ruleset_version: RULESET_VERSION,
+      phase: 'running',
+      cycle_phase: 'day',
+      turn_number: 3,
+      tension_level: 40,
+      created_at: '2026-02-18T00:00:00.000Z',
+      ended_at: null
+    },
+    settings: {
+      surprise_level: 'normal',
+      event_profile: 'balanced',
+      simulation_speed: '1x',
+      seed: 'seed-1'
+    },
+    participants: [
+      {
+        id: 'p1',
+        match_id: 'match-1',
+        character_id: 'char-1',
+        current_health: 100,
+        status: 'alive',
+        streak_score: 0
+      }
+    ],
+    recent_events: []
+  };
+}
+
+describe('validateSnapshotEnvelopeFromRawBody', () => {
+  it('rejects invalid JSON payloads', () => {
+    const result = validateSnapshotEnvelopeFromRawBody('{invalid-json');
+
+    expect(result).toEqual({ ok: false, reason: 'INVALID_JSON' });
+  });
+
+  it('rejects unsupported snapshot version before deep payload parsing', () => {
+    const result = validateSnapshotEnvelopeFromRawBody(
+      JSON.stringify({ snapshot_version: SNAPSHOT_VERSION + 1 })
+    );
+
+    expect(result).toEqual({ ok: false, reason: 'SNAPSHOT_VERSION_UNSUPPORTED' });
+  });
+
+  it('returns validation issues for malformed envelope payload', () => {
+    const result = validateSnapshotEnvelopeFromRawBody(
+      JSON.stringify({
+        snapshot_version: SNAPSHOT_VERSION,
+        checksum: 'abcd1234'
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('INVALID_REQUEST_PAYLOAD');
+      expect(Array.isArray(result.issues)).toBe(true);
+      expect(result.issues?.some((issue) => issue.path.join('.') === 'snapshot')).toBe(true);
+    }
+  });
+
+  it('rejects checksum mismatches', () => {
+    const snapshot = buildSnapshot();
+    const result = validateSnapshotEnvelopeFromRawBody(
+      JSON.stringify({
+        snapshot_version: SNAPSHOT_VERSION,
+        checksum: '00000000',
+        snapshot
+      })
+    );
+
+    expect(result).toEqual({ ok: false, reason: 'SNAPSHOT_INVALID' });
+  });
+
+  it('accepts uppercase checksum values when checksum content is valid', () => {
+    const snapshot = buildSnapshot();
+    const checksum = buildSnapshotChecksum(snapshot).toUpperCase();
+    const result = validateSnapshotEnvelopeFromRawBody(
+      JSON.stringify({
+        snapshot_version: SNAPSHOT_VERSION,
+        checksum,
+        snapshot
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.snapshot.match.id).toBe('match-1');
+    }
+  });
+
+  it('rejects payload larger than max request bytes', () => {
+    const oversizedBody = 'x'.repeat(MAX_SNAPSHOT_REQUEST_BYTES + 1);
+    const result = validateSnapshotEnvelopeFromRawBody(oversizedBody);
+
+    expect(result).toEqual({ ok: false, reason: 'SNAPSHOT_INVALID' });
+  });
+});


### PR DESCRIPTION
## Summary
- harden `canResumeFromLocalStorage` to reject blank ids and non-finite / non-integer / negative turns
- add focused unit tests for `validateSnapshotEnvelopeFromRawBody` (invalid JSON, version mismatch, payload validation issues, checksum mismatch, uppercase checksum, max bytes)
- strengthen rate-limit assertions in create match route tests to enforce full typed error contract shape

## Risk Review (Issue #34)
- High: resume gate accepted malformed numeric turns (`NaN`, `Infinity`, decimals, negatives) and could silently allow invalid runtime state
- Medium: snapshot request validation relied mostly on route integration; missing direct unit guards for parser edge cases
- Medium: rate-limit tests only asserted `error.code`, allowing accidental contract regressions in `error.message/details`

## Validation
- `npm run lint`
- `npm run test:unit`
- `npm run test:coverage`

Closes #34
