### PR TITLE
test: complete remaining issue-34 checklist coverage

### DIFF
--- a/tests/http-errors.test.ts
+++ b/tests/http-errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { jsonError, toValidationIssues } from '@/lib/api/http-errors';
+
+describe('jsonError', () => {
+  it('omits details when not provided', async () => {
+    const response = jsonError('INVALID_JSON', 'Request body must be valid JSON.', 400);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: {
+        code: 'INVALID_JSON',
+        message: 'Request body must be valid JSON.'
+      }
+    });
+  });
+
+  it('preserves typed details payload when provided', async () => {
+    const response = jsonError('INVALID_REQUEST_PAYLOAD', 'Invalid payload.', 400, {
+      issues: [{ path: ['settings', 'seed'], code: 'too_small', message: 'Required' }]
+    });
+    const body = await response.json();
+
+    expect(body).toEqual({
+      error: {
+        code: 'INVALID_REQUEST_PAYLOAD',
+        message: 'Invalid payload.',
+        details: {
+          issues: [{ path: ['settings', 'seed'], code: 'too_small', message: 'Required' }]
+        }
+      }
+    });
+  });
+});
+
+describe('toValidationIssues', () => {
+  it('copies path arrays to avoid shared mutable references', () => {
+    const source = [
+      {
+        path: ['settings', 'seed'] as (string | number)[],
+        code: 'too_small',
+        message: 'Required'
+      }
+    ];
+
+    const mapped = toValidationIssues(source);
+    source[0].path[0] = 'mutated';
+
+    expect(mapped).toEqual([
+      {
+        path: ['settings', 'seed'],
+        code: 'too_small',
+        message: 'Required'
+      }
+    ]);
+  });
+});

--- a/tests/matches-resume-route.test.ts
+++ b/tests/matches-resume-route.test.ts
@@ -45,32 +45,33 @@ describe('POST /api/matches/resume', () => {
     resetRateLimitsForTests();
   });
 
-  it('returns typed error for unsupported content type', async () => {
-    const response = await POST(
-      new Request('http://localhost/api/matches/resume', {
+  it.each([
+    {
+      name: 'unsupported content type',
+      request: new Request('http://localhost/api/matches/resume', {
         method: 'POST',
         headers: { 'content-type': 'text/plain' },
         body: 'x'
-      })
-    );
-    const body = await response.json();
-
-    expect(response.status).toBe(415);
-    expect(body.error.code).toBe('UNSUPPORTED_MEDIA_TYPE');
-  });
-
-  it('returns typed error for invalid JSON body', async () => {
-    const response = await POST(
-      new Request('http://localhost/api/matches/resume', {
+      }),
+      status: 415,
+      code: 'UNSUPPORTED_MEDIA_TYPE'
+    },
+    {
+      name: 'invalid JSON body',
+      request: new Request('http://localhost/api/matches/resume', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: '{bad-json'
-      })
-    );
+      }),
+      status: 400,
+      code: 'INVALID_JSON'
+    }
+  ])('returns typed error for $name', async ({ request, status, code }) => {
+    const response = await POST(request);
     const body = await response.json();
 
-    expect(response.status).toBe(400);
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(response.status).toBe(status);
+    expect(body.error.code).toBe(code);
   });
 
   it('returns typed error for unsupported snapshot version', async () => {

--- a/tests/matches-route.test.ts
+++ b/tests/matches-route.test.ts
@@ -13,42 +13,43 @@ describe('POST /api/matches', () => {
     resetRateLimitsForTests();
   });
 
-  it('returns typed error for unsupported content type', async () => {
-    const request = new Request('http://localhost/api/matches', {
-      method: 'POST',
-      headers: { 'content-type': 'text/plain' },
-      body: 'hello'
-    });
-
+  it.each([
+    {
+      name: 'unsupported content type',
+      request: new Request('http://localhost/api/matches', {
+        method: 'POST',
+        headers: { 'content-type': 'text/plain' },
+        body: 'hello'
+      }),
+      status: 415,
+      body: {
+        error: {
+          code: 'UNSUPPORTED_MEDIA_TYPE',
+          message: 'Content-Type must be application/json.'
+        }
+      }
+    },
+    {
+      name: 'invalid JSON body',
+      request: new Request('http://localhost/api/matches', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{invalid-json'
+      }),
+      status: 400,
+      body: {
+        error: {
+          code: 'INVALID_JSON',
+          message: 'Request body must be valid JSON.'
+        }
+      }
+    }
+  ])('returns typed error for $name', async ({ request, status, body: expectedBody }) => {
     const response = await POST(request);
     const body = await response.json();
 
-    expect(response.status).toBe(415);
-    expect(body).toEqual({
-      error: {
-        code: 'UNSUPPORTED_MEDIA_TYPE',
-        message: 'Content-Type must be application/json.'
-      }
-    });
-  });
-
-  it('returns typed error for invalid JSON body', async () => {
-    const request = new Request('http://localhost/api/matches', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: '{invalid-json'
-    });
-
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(body).toEqual({
-      error: {
-        code: 'INVALID_JSON',
-        message: 'Request body must be valid JSON.'
-      }
-    });
+    expect(response.status).toBe(status);
+    expect(body).toEqual(expectedBody);
   });
 
   it('returns typed error for invalid payload', async () => {

--- a/tests/rate-limit-isolation.test.ts
+++ b/tests/rate-limit-isolation.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { checkRateLimit, resetRateLimitsForTests } from '@/lib/api/rate-limit';
+
+describe('rate limit isolation', () => {
+  beforeEach(() => {
+    resetRateLimitsForTests();
+  });
+
+  it('isolates counters by scope for the same client', () => {
+    const request = new Request('http://localhost/api/matches', {
+      headers: { 'x-forwarded-for': '203.0.113.10' }
+    });
+
+    for (let index = 0; index < 20; index += 1) {
+      expect(checkRateLimit(request, 'create').allowed).toBe(true);
+    }
+
+    expect(checkRateLimit(request, 'create').allowed).toBe(false);
+    expect(checkRateLimit(request, 'resume').allowed).toBe(true);
+  });
+
+  it('isolates counters by client for the same scope', () => {
+    const requestA = new Request('http://localhost/api/matches', {
+      headers: { 'x-forwarded-for': '203.0.113.10' }
+    });
+    const requestB = new Request('http://localhost/api/matches', {
+      headers: { 'x-forwarded-for': '203.0.113.11' }
+    });
+
+    for (let index = 0; index < 20; index += 1) {
+      expect(checkRateLimit(requestA, 'create').allowed).toBe(true);
+    }
+
+    expect(checkRateLimit(requestA, 'create').allowed).toBe(false);
+    expect(checkRateLimit(requestB, 'create').allowed).toBe(true);
+  });
+
+  it('resets bucket after the window expires', () => {
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000);
+
+    const request = new Request('http://localhost/api/matches', {
+      headers: { 'x-forwarded-for': '203.0.113.99' }
+    });
+
+    for (let index = 0; index < 20; index += 1) {
+      expect(checkRateLimit(request, 'create').allowed).toBe(true);
+    }
+
+    expect(checkRateLimit(request, 'create').allowed).toBe(false);
+
+    nowSpy.mockReturnValue(62_000);
+    const afterReset = checkRateLimit(request, 'create');
+    expect(afterReset.allowed).toBe(true);
+    expect(afterReset.retryAfterSeconds).toBe(0);
+  });
+});

--- a/tests/snapshot-request.test.ts
+++ b/tests/snapshot-request.test.ts
@@ -72,6 +72,28 @@ describe('validateSnapshotEnvelopeFromRawBody', () => {
     }
   });
 
+  it('returns validation issues when envelope and snapshot versions mismatch', () => {
+    const snapshot = buildSnapshot();
+    const result = validateSnapshotEnvelopeFromRawBody(
+      JSON.stringify({
+        snapshot_version: SNAPSHOT_VERSION,
+        checksum: buildSnapshotChecksum(snapshot),
+        snapshot: {
+          ...snapshot,
+          snapshot_version: SNAPSHOT_VERSION + 1
+        }
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('INVALID_REQUEST_PAYLOAD');
+      expect(
+        result.issues?.some((issue) => issue.path.join('.') === 'snapshot.snapshot_version')
+      ).toBe(true);
+    }
+  });
+
   it('rejects checksum mismatches', () => {
     const snapshot = buildSnapshot();
     const result = validateSnapshotEnvelopeFromRawBody(


### PR DESCRIPTION
## Summary
- consolidate repeated API negative tests into table-driven `it.each` suites
- add direct mutation-sensitivity tests for `jsonError` and `toValidationIssues`
- add explicit rate-limit isolation tests for scope/client/time-window behavior
- add snapshot envelope/snapshot version mismatch regression test

## Checklist Coverage (remaining items)
- [x] Buscar duplicación de casos con diferente nombre y consolidar en tablas de pruebas (`it.each`)
- [x] Verificar sensibilidad de assertions con pruebas que detectan mutaciones de contrato/mapeo
- [x] Evaluar acoplamiento entre tests cubriendo aislamiento de rate-limit por scope/cliente y ventana temporal

## Validation
- `npm run lint`
- `npm run test:unit`
- `npm run test:coverage`

Related to #34
