### PR TITLE
feat: permitir nombres personalizados de participantes

### DIFF
--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -55,6 +55,7 @@ export type ParticipantState = {
   id: string;
   match_id: string;
   character_id: string;
+  display_name: string;
   current_health: number;
   status: ParticipantStatus;
   streak_score: number;
@@ -92,6 +93,7 @@ export type MatchSnapshot = {
 
 export type CreateMatchRequest = {
   roster_character_ids: string[];
+  participant_names?: string[];
   settings: MatchSettings;
 };
 

--- a/lib/local-runtime.ts
+++ b/lib/local-runtime.ts
@@ -84,6 +84,7 @@ const localRuntimeSnapshotSchema = z
             id: nonEmptyStringSchema,
             match_id: nonEmptyStringSchema,
             character_id: nonEmptyStringSchema,
+            display_name: nonEmptyStringSchema,
             current_health: z.number().int().min(0).max(100),
             status: participantStatusSchema,
             streak_score: z.number().int()

--- a/tests/domain-contracts.test.ts
+++ b/tests/domain-contracts.test.ts
@@ -93,6 +93,7 @@ describe('create_match request contract', () => {
   it('accepts payload with unambiguous required fields', () => {
     const payload = {
       roster_character_ids: Array.from({ length: 10 }, (_, index) => `char-${index + 1}`),
+      participant_names: Array.from({ length: 10 }, (_, index) => `Tributo ${index + 1}`),
       settings: {
         surprise_level: 'normal',
         event_profile: 'balanced',
@@ -140,6 +141,15 @@ describe('create_match request contract', () => {
         extra: 'unexpected'
       },
       extra_root: true
+    };
+
+    expect(createMatchRequestSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects payload when participant_names length does not match roster', () => {
+    const payload = {
+      roster_character_ids: Array.from({ length: 10 }, (_, index) => `char-${index + 1}`),
+      participant_names: ['Solo uno']
     };
 
     expect(createMatchRequestSchema.safeParse(payload).success).toBe(false);

--- a/tests/local-runtime.test.ts
+++ b/tests/local-runtime.test.ts
@@ -27,6 +27,7 @@ function buildRuntime(): LocalRuntimeSnapshot {
         id: 'p1',
         match_id: 'match-1',
         character_id: 'char-01',
+        display_name: 'Atlas',
         current_health: 92,
         status: 'alive',
         streak_score: 1

--- a/tests/matches-resume-route.test.ts
+++ b/tests/matches-resume-route.test.ts
@@ -31,6 +31,7 @@ function buildSnapshot(): MatchSnapshot {
         id: 'p1',
         match_id: 'match-1',
         character_id: 'char-1',
+        display_name: 'char-1',
         current_health: 100,
         status: 'alive',
         streak_score: 0

--- a/tests/matches-route.test.ts
+++ b/tests/matches-route.test.ts
@@ -120,6 +120,24 @@ describe('POST /api/matches', () => {
     expect(body.match_id.length).toBeGreaterThan(0);
   });
 
+  it('accepts participant_names when creating a match', async () => {
+    const request = new Request('http://localhost/api/matches', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        roster_character_ids: roster(10),
+        participant_names: Array.from({ length: 10 }, (_, index) => `Tributo ${index + 1}`)
+      })
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.phase).toBe('setup');
+    expect(typeof body.match_id).toBe('string');
+  });
+
   it('applies defaults when settings are omitted', async () => {
     const request = new Request('http://localhost/api/matches', {
       method: 'POST',

--- a/tests/snapshot-request.test.ts
+++ b/tests/snapshot-request.test.ts
@@ -32,6 +32,7 @@ function buildSnapshot(): MatchSnapshot {
         id: 'p1',
         match_id: 'match-1',
         character_id: 'char-1',
+        display_name: 'char-1',
         current_health: 100,
         status: 'alive',
         streak_score: 0


### PR DESCRIPTION
Closes #44

## Cambios
- Extiende create_match con `participant_names` opcional
- Valida longitud y contenido de nombres personalizados
- Persiste `display_name` en participantes
- Usa nombres personalizados en narrativas/eventos
- Actualiza tests de contratos, rutas y snapshots

## Verificado
- npm run lint
- npm run test:unit
- npm run test:coverage
