### PR TITLE
feat: add frontend custom participant names

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -234,67 +234,13 @@
   grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
 }
 
-.namesGrid {
+.rosterItem {
   display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.nameSummaryCard {
-  border: 1px solid #ecc188;
-  border-radius: 10px;
-  padding: 10px;
-  background: #fffaf2;
-  display: grid;
-  gap: 9px;
-}
-
-.nameSummaryHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.nameChipRow {
-  display: flex;
-  flex-wrap: wrap;
   gap: 6px;
-}
-
-.nameEditor {
-  display: grid;
-  gap: 8px;
-}
-
-.nameTableWrap {
-  max-height: 320px;
-  overflow: auto;
   border: 1px solid #ebc48c;
-  border-radius: 9px;
-  background: #fff;
-}
-
-.nameTable {
-  width: 100%;
-  border-collapse: collapse;
-  min-width: 360px;
-}
-
-.nameTable th,
-.nameTable td {
-  border-bottom: 1px solid #f2dbc0;
+  border-radius: 10px;
   padding: 8px;
-  text-align: left;
-  vertical-align: middle;
-}
-
-.nameTable th {
-  position: sticky;
-  top: 0;
-  background: #fff5e7;
-  z-index: 1;
+  background: #fffdf5;
 }
 
 .characterToggle {


### PR DESCRIPTION
Refs #44

## Cambios
- Agrega inputs para editar nombre de cada tributo seleccionado en Setup
- Valida nombres en cliente (no vacio, max 40)
- Envía `participant_names` al crear partida
- Mantiene nombres personalizados en replay y en labels de UI durante la partida

## Verificado
- npm run lint
- npm run test:unit
- npm run test:coverage
