### PR TITLE
feat: pantalla de carga en transiciones lobby <-> partida

### DIFF
--- a/app/matches/new/page.module.css
+++ b/app/matches/new/page.module.css
@@ -408,6 +408,79 @@
   font-weight: 600;
 }
 
+.transitionOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: grid;
+  place-items: center;
+  background: rgba(28, 18, 10, 0.72);
+  backdrop-filter: blur(2px);
+  animation: overlayIn 200ms ease;
+}
+
+.transitionOverlayExit {
+  animation: overlayOut 180ms ease forwards;
+}
+
+.transitionContent {
+  width: min(90vw, 420px);
+  border: 1px solid #efb969;
+  border-radius: 16px;
+  padding: 20px 18px;
+  text-align: center;
+  background: linear-gradient(165deg, #fff9ea, #fff3dc);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.3);
+}
+
+.transitionSpinner {
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  border: 4px solid rgba(191, 114, 30, 0.24);
+  border-top-color: #bf5f18;
+  margin: 0 auto 12px;
+  animation: spin 780ms linear infinite;
+}
+
+.transitionTitle {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #3f220e;
+}
+
+.transitionHint {
+  margin: 8px 0 0;
+  color: #654226;
+}
+
+@keyframes overlayIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes overlayOut {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (min-width: 980px) {
   .columns {
     grid-template-columns: minmax(300px, 340px) minmax(0, 1fr);
@@ -432,5 +505,14 @@
 
   .speedButton {
     width: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .transitionOverlay,
+  .transitionOverlayExit,
+  .transitionSpinner {
+    animation-duration: 1ms;
+    animation-iteration-count: 1;
   }
 }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -537,6 +537,79 @@
   font-weight: 600;
 }
 
+.transitionOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: grid;
+  place-items: center;
+  background: rgba(28, 18, 10, 0.72);
+  backdrop-filter: blur(2px);
+  animation: overlayIn 200ms ease;
+}
+
+.transitionOverlayExit {
+  animation: overlayOut 180ms ease forwards;
+}
+
+.transitionContent {
+  width: min(90vw, 420px);
+  border: 1px solid #efb969;
+  border-radius: 16px;
+  padding: 20px 18px;
+  text-align: center;
+  background: linear-gradient(165deg, #fff9ea, #fff3dc);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.3);
+}
+
+.transitionSpinner {
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  border: 4px solid rgba(191, 114, 30, 0.24);
+  border-top-color: #bf5f18;
+  margin: 0 auto 12px;
+  animation: spin 780ms linear infinite;
+}
+
+.transitionTitle {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #3f220e;
+}
+
+.transitionHint {
+  margin: 8px 0 0;
+  color: #654226;
+}
+
+@keyframes overlayIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes overlayOut {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (min-width: 980px) {
   .columns {
     grid-template-columns: minmax(300px, 340px) minmax(0, 1fr);
@@ -569,5 +642,14 @@
 
   .speedButton {
     width: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .transitionOverlay,
+  .transitionOverlayExit,
+  .transitionSpinner {
+    animation-duration: 1ms;
+    animation-iteration-count: 1;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,9 +7,29 @@ import { MatchList } from '@/app/components/match-list';
 import { loadLocalMatchesFromStorage, type LocalMatchSummary } from '@/lib/local-matches';
 import { quickAccessMatches } from '@/lib/match-ux';
 
+const TRANSITION_STORAGE_KEY = 'hg_transition';
+const TRANSITION_MIN_VISIBLE_MS = 700;
+const TRANSITION_LONG_WAIT_MS = 3000;
+const TRANSITION_FADE_OUT_MS = 180;
+
+type TransitionDirection = 'lobby_to_match' | 'match_to_lobby';
+
+type TransitionOverlayState = {
+  direction: TransitionDirection;
+  showLongWait: boolean;
+  isExiting: boolean;
+};
+
+function waitMs(durationMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, durationMs);
+  });
+}
+
 export default function Home() {
   const [localMatches, setLocalMatches] = useState<LocalMatchSummary[]>([]);
   const [infoMessage, setInfoMessage] = useState<string | null>(null);
+  const [transitionOverlay, setTransitionOverlay] = useState<TransitionOverlayState | null>(null);
 
   useEffect(() => {
     const { matches, error } = loadLocalMatchesFromStorage(window.localStorage);
@@ -20,9 +40,94 @@ export default function Home() {
   }, []);
 
   const quickMatches = useMemo(() => quickAccessMatches(localMatches, 6), [localMatches]);
+  const isTransitioning = transitionOverlay !== null;
+
+  useEffect(() => {
+    const raw = window.sessionStorage.getItem(TRANSITION_STORAGE_KEY);
+    if (!raw) {
+      return;
+    }
+
+    let parsed: { direction?: string; startedAt?: number } | null = null;
+    try {
+      parsed = JSON.parse(raw) as { direction?: string; startedAt?: number };
+    } catch {
+      window.sessionStorage.removeItem(TRANSITION_STORAGE_KEY);
+      return;
+    }
+
+    if (parsed?.direction !== 'match_to_lobby' || typeof parsed.startedAt !== 'number') {
+      return;
+    }
+
+    window.sessionStorage.removeItem(TRANSITION_STORAGE_KEY);
+
+    const elapsedMs = Date.now() - parsed.startedAt;
+    const remainingMinMs = Math.max(0, TRANSITION_MIN_VISIBLE_MS - elapsedMs);
+    const remainingLongWaitMs = Math.max(0, TRANSITION_LONG_WAIT_MS - elapsedMs);
+    let longWaitId = 0;
+
+    setTransitionOverlay({
+      direction: 'match_to_lobby',
+      showLongWait: elapsedMs >= TRANSITION_LONG_WAIT_MS,
+      isExiting: false
+    });
+
+    if (elapsedMs < TRANSITION_LONG_WAIT_MS) {
+      longWaitId = window.setTimeout(() => {
+        setTransitionOverlay((current) => {
+          if (!current || current.direction !== 'match_to_lobby' || current.isExiting) {
+            return current;
+          }
+
+          return { ...current, showLongWait: true };
+        });
+      }, remainingLongWaitMs);
+    }
+
+    void (async () => {
+      if (remainingMinMs > 0) {
+        await waitMs(remainingMinMs);
+      }
+
+      window.clearTimeout(longWaitId);
+      setTransitionOverlay((current) =>
+        current ? { ...current, isExiting: true } : current
+      );
+      await waitMs(TRANSITION_FADE_OUT_MS);
+      setTransitionOverlay(null);
+    })();
+
+    return () => {
+      window.clearTimeout(longWaitId);
+    };
+  }, []);
+
+  function startTransitionToMatch(): void {
+    const startedAt = Date.now();
+    window.sessionStorage.setItem(
+      TRANSITION_STORAGE_KEY,
+      JSON.stringify({ direction: 'lobby_to_match', startedAt })
+    );
+    setTransitionOverlay({
+      direction: 'lobby_to_match',
+      showLongWait: false,
+      isExiting: false
+    });
+
+    window.setTimeout(() => {
+      setTransitionOverlay((current) => {
+        if (!current || current.direction !== 'lobby_to_match' || current.isExiting) {
+          return current;
+        }
+
+        return { ...current, showLongWait: true };
+      });
+    }, TRANSITION_LONG_WAIT_MS);
+  }
 
   return (
-    <main className={styles.page}>
+    <main className={styles.page} aria-busy={isTransitioning}>
       <div className={styles.shell}>
         <header className={styles.hero}>
           <div className={styles.heroTop}>
@@ -32,7 +137,7 @@ export default function Home() {
           <p className={styles.heroMeta}>Accede rapido a partidas recientes o crea una nueva.</p>
 
           <div className={styles.inlineControls}>
-            <Link className={styles.button} href="/matches/new">
+            <Link className={styles.button} href="/matches/new" onClick={startTransitionToMatch}>
               Iniciar partida
             </Link>
             <Link className={`${styles.button} ${styles.buttonGhost}`} href="/matches">
@@ -50,14 +155,18 @@ export default function Home() {
             emptyState={
               <div>
                 <p>No hay partidas guardadas todavia.</p>
-                <Link className={styles.button} href="/matches/new">
+                <Link className={styles.button} href="/matches/new" onClick={startTransitionToMatch}>
                   Iniciar partida
                 </Link>
               </div>
             }
             renderActions={(match) => (
               <>
-                <Link className={styles.button} href={`/matches/new?resume=${match.id}`}>
+                <Link
+                  className={styles.button}
+                  href={`/matches/new?resume=${match.id}`}
+                  onClick={startTransitionToMatch}
+                >
                   Reanudar
                 </Link>
                 <Link className={`${styles.button} ${styles.buttonGhost}`} href={`/matches/${match.id}`}>
@@ -70,6 +179,28 @@ export default function Home() {
 
         {infoMessage ? <p className={styles.info}>{infoMessage}</p> : null}
       </div>
+      {transitionOverlay ? (
+        <div
+          className={`${styles.transitionOverlay} ${transitionOverlay.isExiting ? styles.transitionOverlayExit : ''}`}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <div className={styles.transitionContent}>
+            <div className={styles.transitionSpinner} aria-hidden="true" />
+            <p className={styles.transitionTitle}>
+              {transitionOverlay.direction === 'match_to_lobby'
+                ? 'Volviendo al lobby...'
+                : 'Preparando la arena...'}
+            </p>
+            <p className={styles.transitionHint}>
+              {transitionOverlay.showLongWait
+                ? 'Esto esta tardando mas de lo esperado. Espera un momento...'
+                : 'Sincronizando estado de la partida.'}
+            </p>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }


### PR DESCRIPTION
## Resumen
- agrega overlay full-screen de carga para transiciones Lobby -> Partida y Partida -> Lobby
- garantiza tiempo minimo visible de 700ms y mensaje de espera extendida luego de 3000ms
- incorpora animacion de fade, spinner continuo y soporte prefers-reduced-motion
- agrega control Volver al lobby en vista de partida

## Accesibilidad
- role="status" + aria-live="polite" para anuncio de carga
- aria-busy en la vista principal durante la transicion

## Validacion
- npm run lint
- npm run test:unit
- npm run validate

Closes #52
