### PR TITLE
feat: integrar Vercel Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Aplicacion local: [http://localhost:3000](http://localhost:3000)
 | `npm run test:coverage` | Tests con cobertura |
 | `npm run validate` | Gate completo (`lint + unit + coverage`) |
 
+## Observabilidad (Vercel Analytics)
+
+- Integracion base habilitada con `@vercel/analytics` en `app/layout.tsx`.
+- Para validar eventos en produccion:
+  1. Desplegar la app en Vercel.
+  2. Abrir el deployment y navegar por la app para generar trafico.
+  3. Ir a `Vercel Dashboard -> Project -> Analytics` y confirmar recepcion de eventos/paginas.
+
 ## Flujo funcional
 
 1. Crear setup de partida (`/matches/new`) con roster, seed opcional y perfil.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { Analytics } from '@vercel/analytics/react';
 
 export const metadata: Metadata = {
   title: 'Hunger Games Simulator',
@@ -13,7 +14,10 @@ type RootLayoutProps = {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="es">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hunger-games",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^1.6.1",
         "next": "15.5.12",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -2475,6 +2476,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.6.1",
     "next": "15.5.12",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
## Resumen
- agrega dependencia `@vercel/analytics`
- integra `<Analytics />` en `app/layout.tsx`
- documenta validacion en Vercel Analytics en README

## Validacion
- npm run lint
- npm run test:unit
- npm run test:coverage
- npm run build

Closes #57
