### PR TITLE
feat: agregar Cloudflare Web Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,24 @@ Aplicacion local: [http://localhost:3000](http://localhost:3000)
 | `npm run test:coverage` | Tests con cobertura |
 | `npm run validate` | Gate completo (`lint + unit + coverage`) |
 
-## Observabilidad (Vercel Analytics)
+## Observabilidad
 
-- Integracion base habilitada con `@vercel/analytics` en `app/layout.tsx`.
-- Para validar eventos en produccion:
-  1. Desplegar la app en Vercel.
-  2. Abrir el deployment y navegar por la app para generar trafico.
-  3. Ir a `Vercel Dashboard -> Project -> Analytics` y confirmar recepcion de eventos/paginas.
+- Vercel Analytics habilitado en `app/layout.tsx` con `@vercel/analytics`.
+- Cloudflare Web Analytics habilitado en `app/layout.tsx` usando el beacon oficial.
+- Configuracion necesaria para Cloudflare:
+  - definir `NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN` en el entorno de despliegue.
+
+### Validar Vercel Analytics
+
+1. Desplegar la app en Vercel.
+2. Navegar por la app para generar trafico.
+3. Revisar `Vercel Dashboard -> Project -> Analytics`.
+
+### Validar Cloudflare Web Analytics
+
+1. Configurar el token de Web Analytics de Cloudflare en `NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN`.
+2. Desplegar y navegar la app.
+3. Revisar `Cloudflare Dashboard -> Web Analytics` y confirmar page views/eventos.
 
 ## Flujo funcional
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import type { ReactNode } from 'react';
 import { Analytics } from '@vercel/analytics/react';
 
@@ -12,11 +13,22 @@ type RootLayoutProps = {
 };
 
 export default function RootLayout({ children }: RootLayoutProps) {
+  const cloudflareAnalyticsToken =
+    process.env.NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN;
+
   return (
     <html lang="es">
       <body>
         {children}
         <Analytics />
+        {cloudflareAnalyticsToken ? (
+          <Script
+            defer
+            src="https://static.cloudflareinsights.com/beacon.min.js"
+            data-cf-beacon={JSON.stringify({ token: cloudflareAnalyticsToken })}
+            strategy="afterInteractive"
+          />
+        ) : null}
       </body>
     </html>
   );


### PR DESCRIPTION
## Resumen
- agrega `@vercel/analytics` y mantiene `<Analytics />` en layout raiz
- agrega Cloudflare Web Analytics beacon en `app/layout.tsx`
- condiciona beacon por `NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN`
- documenta validacion de ambas analiticas en README

## Validacion
- npm run lint
- npm run build
