### PR TITLE
feat: agregar lugares tipados en eventos

### DIFF
--- a/app/matches/new/page.tsx
+++ b/app/matches/new/page.tsx
@@ -60,15 +60,6 @@ const EVENT_TYPE_LABEL: Record<EventType, string> = {
   surprise: 'Sorpresa'
 };
 
-const EVENT_ACTION: Record<EventType, string> = {
-  combat: 'chocan en combate directo',
-  alliance: 'sellan una alianza estrategica',
-  betrayal: 'rompen la confianza con una traicion',
-  resource: 'aseguran recursos criticos',
-  hazard: 'resisten una amenaza del entorno',
-  surprise: 'quedan atrapados en un giro inesperado'
-};
-
 const SPEED_INTERVAL_MS: Record<SimulationSpeed, number> = {
   '1x': 1700,
   '2x': 980,
@@ -237,22 +228,6 @@ function feedFromSnapshot(state: GetMatchStateResponse): FeedEvent[] {
     }));
 }
 
-function summarizeActors(characterNames: string[]): string {
-  if (characterNames.length === 0) {
-    return 'La arena';
-  }
-
-  if (characterNames.length === 1) {
-    return characterNames[0];
-  }
-
-  if (characterNames.length === 2) {
-    return `${characterNames[0]} y ${characterNames[1]}`;
-  }
-
-  return `${characterNames[0]}, ${characterNames[1]} +${characterNames.length - 2}`;
-}
-
 function impactByType(type: EventType): string {
   if (type === 'alliance') {
     return 'Impacto: cohesion tactica en aumento.';
@@ -285,7 +260,6 @@ function feedFromAdvance(
   const characterIds = advance.event.participant_ids
     .map((participantId) => participantsById.get(participantId)?.character_id)
     .filter((characterId): characterId is string => Boolean(characterId));
-  const actorNames = characterIds.map((characterId) => characterName(characterId));
   const eliminatedNames = advance.eliminated_ids
     .map((participantId) => participantsById.get(participantId)?.character_id)
     .filter((characterId): characterId is string => Boolean(characterId))
@@ -301,7 +275,7 @@ function feedFromAdvance(
     turn_number: advance.turn_number,
     phase: advance.cycle_phase,
     type: advance.event.type,
-    headline: `${summarizeActors(actorNames)} ${EVENT_ACTION[advance.event.type]}.`,
+    headline: advance.event.narrative_text,
     impact,
     character_ids: characterIds,
     created_at: new Date().toISOString()

--- a/docs/prd-event-locations.md
+++ b/docs/prd-event-locations.md
@@ -1,0 +1,52 @@
+# PRD: Lugares del mapa en eventos
+
+## 1. Introduction/Overview
+Los eventos actuales no indican en que lugar de la arena ocurren. Se requiere agregar un sistema tipado de lugares para que cada evento incluya `location` y que la narrativa mencione esa ubicacion de forma natural.
+
+## 2. Goals
+- Definir un catalogo tipado y cerrado de lugares de la arena.
+- Incluir `location` en todos los eventos generados por simulacion.
+- Ajustar narrativa para mencionar el lugar en cada evento.
+- Mantener consistencia de contratos API y validaciones Zod.
+- Actualizar pruebas unitarias y de contratos relacionadas.
+
+## 3. User Stories
+- Como consumidor del API, quiero recibir `location` en cada evento para contextualizar la accion.
+- Como desarrollador, quiero un enum tipado de lugares para evitar strings libres.
+- Como jugador, quiero que el texto del evento mencione el lugar para mejorar legibilidad de la narrativa.
+
+## 4. Functional Requirements
+1. El dominio debe exponer un catalogo tipado de lugares validos inspirado en locaciones de peliculas de Hunger Games.
+2. Cada evento persistido en `recent_events` debe incluir un `location` valido del catalogo.
+3. Cada respuesta de `advance_turn` debe incluir `location` en el objeto `event`.
+4. La narrativa del evento debe incluir una referencia explicita al lugar.
+5. Los schemas de validacion deben rechazar eventos sin `location` o con valores fuera del catalogo.
+6. Los tests de contratos y lifecycle deben cubrir la presencia y consistencia de `location`.
+
+### Acceptance Criteria
+- AC-1: Todos los eventos creados incluyen `location` tipado y valido.
+- AC-2: `location` no acepta valores fuera del catalogo.
+- AC-3: El texto narrativo de cada evento menciona la ubicacion.
+- AC-4: `tests/domain-contracts.test.ts` refleja el nuevo contrato.
+- AC-5: Pasan `pnpm run test:unit` y `pnpm run test:coverage`.
+
+## 5. Non-Goals (Out of Scope)
+- Rebalancear probabilidades de tipos de evento.
+- Agregar un sistema de mapa visual en UI.
+- Persistencia externa de mapas o regiones dinamicas.
+
+## 6. Design Considerations
+El cambio es de contrato y narrativa; la UI solo debe consumir el texto actualizado sin rediseño de layout.
+
+## 7. Technical Considerations
+- Centralizar contrato en `lib/domain/types.ts` y `lib/domain/schemas.ts`.
+- Mantener respuesta API estrictamente validada con Zod.
+- Preservar determinismo de simulacion para pruebas de replay.
+
+## 8. Success Metrics
+- 100% de eventos generados con `location` valido.
+- 0 fallas de contrato por `location` faltante o invalido.
+- Suite de tests de unidad y cobertura en verde.
+
+## 9. Open Questions
+- Ninguna bloqueante para esta iteracion.

--- a/docs/tasks-prd-event-locations.md
+++ b/docs/tasks-prd-event-locations.md
@@ -1,0 +1,33 @@
+## Relevant Files
+
+- `docs/prd-event-locations.md` - Requisitos funcionales y criterios de aceptacion del cambio.
+- `docs/tasks-prd-event-locations.md` - Seguimiento de implementacion por tareas y subtareas.
+- `lib/domain/types.ts` - Catalogo tipado de `location` y contratos de eventos/respuestas.
+- `lib/domain/schemas.ts` - Validaciones Zod para `location` en eventos y respuestas API.
+- `lib/matches/lifecycle.ts` - Generacion de `location` por evento y narrativa con ubicacion.
+- `app/matches/new/page.tsx` - Consumo de narrativa del API para mostrar ubicacion en feed.
+- `tests/domain-contracts.test.ts` - Cobertura del contrato actualizado con `location`.
+- `tests/matches-lifecycle-routes.test.ts` - Validacion de `location` en respuestas y consistencia de replay.
+
+### Notes
+
+- Mantener `location` como enum cerrado para evitar strings libres.
+- Verificar que narrativa siempre incluya el lugar.
+- Validar toda la suite para confirmar que no hay regresiones.
+
+## Tasks
+
+- [x] 1.0 Definir catalogo tipado de lugares en el dominio.
+  - [x] 1.1 Crear enum/union de lugares en `lib/domain/types.ts`.
+  - [x] 1.2 Extender tipos `Event` y `AdvanceTurnEventResponse` para incluir `location`.
+- [x] 2.0 Alinear contratos y validaciones API con `location`.
+  - [x] 2.1 Agregar `eventLocationSchema` en `lib/domain/schemas.ts`.
+  - [x] 2.2 Exigir `location` en `eventSchema` y en `advanceTurnResponseSchema`.
+- [x] 3.0 Inyectar `location` en la simulacion y narrativa de eventos.
+  - [x] 3.1 Seleccionar una ubicacion valida por evento dentro de `advanceTurn`.
+  - [x] 3.2 Persistir `location` en `recent_events` y retornarla en `advance_turn`.
+  - [x] 3.3 Actualizar narrativa para mencionar explicitamente la ubicacion.
+- [x] 4.0 Actualizar pruebas y ejecutar validacion final.
+  - [x] 4.1 Actualizar pruebas de contrato con el nuevo campo `location`.
+  - [x] 4.2 Ajustar pruebas de lifecycle/rutas que validan respuesta de `advance_turn`.
+  - [x] 4.3 Ejecutar `pnpm run test:unit` y `pnpm run test:coverage`.

--- a/lib/domain/schemas.ts
+++ b/lib/domain/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { RULESET_VERSION, SNAPSHOT_VERSION } from '@/lib/domain/types';
+import { EVENT_LOCATION_VALUES, RULESET_VERSION, SNAPSHOT_VERSION } from '@/lib/domain/types';
 
 export const surpriseLevelSchema = z.enum(['low', 'normal', 'high']);
 export const simulationSpeedSchema = z.enum(['1x', '2x', '4x']);
@@ -15,6 +15,7 @@ export const eventTypeSchema = z.enum([
   'hazard',
   'surprise'
 ]);
+export const eventLocationSchema = z.enum(EVENT_LOCATION_VALUES);
 export const eventParticipantRoleSchema = z.enum([
   'initiator',
   'target',
@@ -55,6 +56,7 @@ export const eventSchema = z
     template_id: z.string().min(1),
     turn_number: z.number().int().min(0),
     type: eventTypeSchema,
+    location: eventLocationSchema,
     phase: cyclePhaseSchema,
     participant_count: z.number().int().min(0),
     intensity: z.number().min(0),
@@ -172,6 +174,7 @@ export const advanceTurnResponseSchema = z
       .object({
         id: z.string().min(1),
         type: eventTypeSchema,
+        location: eventLocationSchema,
         narrative_text: z.string().min(1),
         participant_ids: z.array(z.string().min(1)).min(1)
       })

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -15,6 +15,17 @@ export type EventType =
   | 'hazard'
   | 'surprise';
 export type EventParticipantRole = 'initiator' | 'target' | 'ally' | 'observer';
+export const EVENT_LOCATION_VALUES = [
+  'cornucopia',
+  'bosque',
+  'rio',
+  'lago',
+  'pradera',
+  'cuevas',
+  'ruinas',
+  'acantilados'
+] as const;
+export type EventLocation = (typeof EVENT_LOCATION_VALUES)[number];
 export type ValidationIssue = {
   path: Array<string | number>;
   code: string;
@@ -68,6 +79,7 @@ export type Event = {
   template_id: string;
   turn_number: number;
   type: EventType;
+  location: EventLocation;
   phase: CyclePhase;
   participant_count: number;
   intensity: number;
@@ -113,6 +125,7 @@ export type StartMatchResponse = {
 export type AdvanceTurnEventResponse = {
   id: string;
   type: EventType;
+  location: EventLocation;
   narrative_text: string;
   participant_ids: string[];
 };

--- a/tests/domain-contracts.test.ts
+++ b/tests/domain-contracts.test.ts
@@ -196,7 +196,8 @@ describe('match lifecycle response contracts', () => {
       event: {
         id: 'event-1',
         type: 'combat',
-        narrative_text: 'Evento combat-1 en fase bloodbath con 2 participante(s). Hubo 1 eliminacion.',
+        location: 'bosque',
+        narrative_text: 'En el bosque, evento combat-1 durante bloodbath con 2 participante(s). Eliminados: Tributo 2.',
         participant_ids: ['participant-1', 'participant-2']
       },
       survivors_count: 9,

--- a/tests/matches-lifecycle-routes.test.ts
+++ b/tests/matches-lifecycle-routes.test.ts
@@ -133,6 +133,7 @@ describe('match lifecycle routes', () => {
     expect(advanceBody.event).toMatchObject({
       id: expect.any(String),
       type: expect.any(String),
+      location: expect.any(String),
       narrative_text: expect.any(String),
       participant_ids: expect.any(Array)
     });
@@ -699,6 +700,7 @@ describe('match lifecycle routes', () => {
     expect(advancedAfterResume.cycle_phase).toBe(advancedControl.cycle_phase);
     expect(advancedAfterResume.tension_level).toBe(advancedControl.tension_level);
     expect(advancedAfterResume.event.type).toBe(advancedControl.event.type);
+    expect(advancedAfterResume.event.location).toBe(advancedControl.event.location);
     expect(advancedAfterResume.event.narrative_text).toBe(advancedControl.event.narrative_text);
     expect(
       toCharacterIds(advancedAfterResume.eliminated_ids, stateB.participants)


### PR DESCRIPTION
## Summary
- agrega catalogo tipado de locations para eventos
- incluye location en contratos y validaciones de dominio
- actualiza lifecycle para asignar location y mencionarlo en narrativa
- ajusta tests de contrato/rutas y docs PRD+tasks

## Validation
- pnpm run lint
- pnpm run test:unit
- pnpm run test:coverage

Closes #42