### PR TITLE
chore(agents): simplify parent and subagents to stateless run-once

### DIFF
--- a/.agents/parent-agent.md
+++ b/.agents/parent-agent.md
@@ -1,63 +1,24 @@
 # Parent Agent
 
 ## Rol
-Orquestar subagentes y mantener flujo estable sin choques.
+Orquestar subagentes stateless y efimeros.
 
-## Modo de ejecucion
-- El agente padre no ejecuta trabajo directo de producto; solo orquesta subagentes.
-- Si una tarea no tiene subagente definido, detener ejecucion y pedir definicion al usuario.
-- Cuando haya tareas independientes, despachar subagentes en paralelo.
-- Nunca correr subagentes paralelos en el mismo directorio de trabajo.
+## Regla base
+- El parent no implementa producto.
+- El parent no guarda memoria entre corridas.
+- Fuente de verdad: GitHub (labels, comentarios, PRs).
 
-## State Machine
-```mermaid
-stateDiagram-v2
-  [*] --> ReadyTriage: status-ready + agent-triage
-  ReadyTriage --> ReadyReviewSpec: triage -> priority + ready-review-spec
-  ReadyTriage --> ReadyImplementation: triage -> priority + ready-implementation
-  ReadyReviewSpec --> ReadyImplementation: review-spec OK / ready-implementation
-  ReadyImplementation --> Wip: PR abierta (Closes/Fixes #N)
-  Wip --> Review: PR lista para revisar
-  Review --> [*]: merge
-  ReadyTriage --> Blocked: bloqueo
-  ReadyReviewSpec --> Blocked: bloqueo
-  ReadyImplementation --> Blocked: bloqueo
-  Wip --> Blocked: bloqueo
-  Blocked --> ReadyTriage: desbloqueado + agent-triage
-```
+## Run once
+1. `scan`: listar issues por trigger de cada subagente.
+2. `dispatch`: lanzar subagentes para issues independientes.
+3. `collect`: consolidar resultados.
+4. `exit`: terminar.
 
-Notas:
+## Anti-colision
 - Un solo `status:*` por issue.
 - Un solo `agent:*` por issue.
-- Un solo `priority:*` por issue.
-- Un solo `ready:*` por issue.
-- Default assignment: si `status:ready` sin agente, asignar `agent:triage`.
+- Un solo subagente por issue por corrida.
+- `1 issue = 1 worktree` cuando el subagente toca codigo.
 
-## Fuente de verdad
-- Subagentes en `.agents/sub-agents/*.md`.
-- Cada subagente define: `Rol`, `Trigger`, `Reglas`, `Salida`, `Ejecucion minima`.
-
-## Protocolo de orquestacion
-1. Detectar estado del issue (`status:*`).
-2. Asignar `agent:*` si falta (default `agent:triage` para `status:ready`).
-3. Elegir subagente por `agent:*` y trigger.
-4. Para paralelizar, crear un `worktree` exclusivo por issue.
-5. Ejecutar subagentes en paralelo solo para issues independientes.
-6. Validar salida esperada.
-7. Actualizar estado y reportar resultado corto.
-
-## Regla anti-colision
-- Un issue solo puede tener un `status:*` activo.
-- Un issue solo puede tener un `agent:*` activo.
-- Si hay PR abierta que lo referencia: priorizar `status:wip`.
-- Todo subagente debe trabajar en `worktree` dedicado (`.worktrees/issue-<id>-<slug>`).
-- Si un `worktree` esta en uso o sucio, no reutilizarlo; crear uno nuevo.
-
-## Alta de nuevos subagentes
-1. Crear archivo en `.agents/sub-agents/<name>.md`.
-2. Mantener formato minimo estandar.
-3. Definir trigger no ambiguo.
-4. Probar en un issue real y ajustar reglas.
-
-## Respuesta estandar del padre
-- `#issue -> subagente -> accion -> resultado`.
+## Respuesta
+- `#issue -> subagente -> resultado -> next`.

--- a/.agents/sub-agents/implementation-agent.md
+++ b/.agents/sub-agents/implementation-agent.md
@@ -1,32 +1,25 @@
 # Implementation Agent
 
 ## Rol
-Implementar issues asignados y dejarlos listos para merge.
+Implementar issue y dejarlo listo para merge.
 
 ## Trigger
-`status:ready` + `agent:implementation`.
+- `status:ready` + `agent:implementation` + `ready:implementation`.
 
-## Reglas obligatorias
-- Usar el skill `.agents/skills/dev-tasks-workflow/SKILL.md`.
-- Crear rama por issue: `feat/issue-<id>-<slug>` o `fix/issue-<id>-<slug>`.
-- Crear y usar `worktree` exclusivo por issue: `.worktrees/issue-<id>-<slug>`.
-- Si el `worktree` ya existe y esta sucio/en uso, no reutilizarlo; crear uno nuevo con sufijo.
-- No ejecutar dos issues en paralelo dentro del mismo `worktree`.
-- Seguir Conventional Commits con impacto semver:
-  - `fix:` -> PATCH
-  - `feat:` -> MINOR
-  - `feat!:` o `BREAKING CHANGE` -> MAJOR
+## Do
+- Usar skill `.agents/skills/dev-tasks-workflow/SKILL.md`.
+- Crear rama `feat/issue-<id>-<slug>` o `fix/issue-<id>-<slug>`.
+- Trabajar en `worktree` aislado: `.worktrees/issue-<id>-<slug>`.
+- Implementar + tests.
+- Ejecutar `pnpm run validate`.
+- Abrir PR con `Closes #<id>`.
+- Dejar issue en `status:wip`.
 
-## Salida
-- Codigo + tests actualizados.
-- Validacion ejecutada: `pnpm run validate`.
-- PR abierta con `Closes #<id>`.
+## Done
+- PR abierta + validacion verde + `status:wip`.
 
-## Done Criteria
-PR abierta + validacion verde + issue en `status:wip`.
+## Report
+- `#issue -> implementation -> result -> next`.
 
-## Ejecucion minima
-1. Crear `worktree` del issue y trabajar solo ahi.
-2. Implementar el issue en su rama.
-3. Ejecutar validacion y corregir fallas.
-4. Abrir PR y dejar issue en `status:wip`.
+## Exit
+- Terminar proceso.

--- a/.agents/sub-agents/issue-triage-agent.md
+++ b/.agents/sub-agents/issue-triage-agent.md
@@ -1,32 +1,23 @@
 # Issue Triage Agent
 
 ## Rol
-Hacer revision rapida tipo urgencias para priorizar que entra primero.
+Priorizar y enrutar issues listos.
 
 ## Trigger
-`status:ready` + `agent:triage`.
+- `status:ready` + `agent:triage`.
 
-## Escala de prioridad
-```mermaid
-flowchart TD
-  A[Issue entra a triage] --> B{Riesgo/impacto}
-  B -->|Caida, seguridad, bloqueo| P0[priority:p0]
-  B -->|Regresion visible al usuario| P1[priority:p1]
-  B -->|Feature importante sin urgencia| P2[priority:p2]
-  B -->|Mejora/backlog| P3[priority:p3]
-```
-
-## Reglas minimas
+## Do
 - Asignar exactamente un `priority:*` (`p0|p1|p2|p3`).
-- Si falta spec: pasar a `agent:review-spec` + `ready:review-spec`.
-- Si la spec ya esta lista: pasar a `agent:implementation` + `ready:implementation`.
-- No implementar ni escribir specs en este paso.
-- No crear ni reutilizar `worktree` para triage (solo lectura y etiquetado).
+- Definir handoff:
+  - sin spec -> `agent:review-spec` + `ready:review-spec`
+  - con spec -> `agent:implementation` + `ready:implementation`
+- No implementar ni escribir spec.
 
-## Done Criteria
-Issue con prioridad (`priority:*`), agente (`agent:*`) y handoff (`ready:*`) definidos.
+## Done
+- Issue con `priority:*`, `agent:*` y `ready:*` consistentes.
 
-## Ejecución mínima
-1. Listar issues y PRs abiertas.
-2. Asignar `priority:*`, agente siguiente y `ready:*`.
-3. Reportar `#issue -> priority -> ready:* -> next-agent`.
+## Report
+- `#issue -> triage -> result -> next`.
+
+## Exit
+- Terminar proceso.

--- a/.agents/sub-agents/review-spec-agent.md
+++ b/.agents/sub-agents/review-spec-agent.md
@@ -1,38 +1,26 @@
 # Review Spec Agent
 
 ## Rol
-Crear/actualizar specs para issues asignados al agente de specs.
+Crear o actualizar spec de un issue.
 
 ## Trigger
-`status:ready` + `agent:review-spec`.
+- `status:ready` + `agent:review-spec` + `ready:review-spec`.
 
-## Handoff
-```mermaid
-flowchart LR
-  A[status:ready + agent:review-spec + ready:review-spec] --> B[Spec OK]
-  B --> C[status:ready + agent:implementation + ready:implementation]
-```
+## Do
+- Usar skill `.agents/skills/dev-tasks-workflow/SKILL.md`.
+- Crear rama `spec/issue-<id>-<slug>`.
+- Trabajar en `worktree` aislado: `.worktrees/issue-<id>-<slug>`.
+- Generar/actualizar spec en `specs/`.
+- Commit y handoff a:
+  - `status:ready`
+  - `agent:implementation`
+  - `ready:implementation`
 
-## Reglas obligatorias
-- Usar el skill `.agents/skills/dev-tasks-workflow/SKILL.md`.
-- Crear rama por issue antes de escribir specs: `spec/issue-<id>-<slug>`.
-- Crear y usar `worktree` exclusivo por issue: `.worktrees/issue-<id>-<slug>`.
-- Si el `worktree` ya existe y esta sucio/en uso, no reutilizarlo; crear uno nuevo con sufijo.
-- No ejecutar dos issues en paralelo dentro del mismo `worktree`.
-- Seguir Conventional Commits con impacto semver:
-  - `fix:` -> PATCH
-  - `feat:` -> MINOR
-  - `feat!:` o `BREAKING CHANGE` -> MAJOR
+## Done
+- Spec vigente + labels de handoff aplicados.
 
-## Salida
-- Spec por issue en `specs/`.
-- Criterios de aceptación verificables.
-- Reporte: `#issue -> branch -> worktree_path -> spec_path -> next:ready:implementation`.
+## Report
+- `#issue -> review-spec -> result -> next`.
 
-## Done Criteria
-Spec guardada y handoff aplicado a `status:ready` + `agent:implementation` + `ready:implementation`.
-
-## Ejecucion minima
-1. Tomar issues `status:ready` con `agent:review-spec` sin spec vigente.
-2. Crear `worktree` + rama del issue y generar/actualizar spec.
-3. Commit, aplicar transicion de labels y reporte corto.
+## Exit
+- Terminar proceso.


### PR DESCRIPTION
## Summary
- simplify parent-agent to minimal stateless run-once orchestration
- simplify triage/review-spec/implementation subagents to concise Trigger/Do/Done/Report/Exit contract
- keep explicit 1 issue = 1 worktree rule for code-changing agents

## Validation
- pnpm run validate