### PR TITLE
fix: aislar reglas de eventos especiales y pruebas determinísticas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2026-02-23
+
+### Fixed
+
+- Refactor `advanceTurn` to delegate special event resolution and narrative generation to dedicated modules.
+- Centralize early-pedestal special-event rules in `lib/domain/rules.ts` as versioned domain config.
+- Replace seed brute-force tests with deterministic unit tests driven by controlled RNG rolls.
+
 ## [0.1.1] - 2026-02-23
 
 ### Fixed

--- a/lib/domain/rules.ts
+++ b/lib/domain/rules.ts
@@ -1,0 +1,17 @@
+import { RULESET_VERSION } from '@/lib/domain/types';
+
+export type SpecialEventRules = {
+  version: string;
+  early_pedestal_escape: {
+    template_id: string;
+    explosion_chance: number;
+  };
+};
+
+export const SPECIAL_EVENT_RULES: SpecialEventRules = {
+  version: RULESET_VERSION,
+  early_pedestal_escape: {
+    template_id: 'hazard-pedestal-early-exit-1',
+    explosion_chance: 0.08
+  }
+};

--- a/lib/matches/event-narrative.ts
+++ b/lib/matches/event-narrative.ts
@@ -1,0 +1,28 @@
+import type { Match } from '@/lib/domain/types';
+import type { SpecialEventNarrative } from '@/lib/matches/special-events';
+
+type BuildEventNarrativeInput = {
+  template_id: string;
+  phase: Match['cycle_phase'];
+  participant_names: string[];
+  eliminated_names: string[];
+  special_narrative: SpecialEventNarrative;
+};
+
+export function buildEventNarrative(input: BuildEventNarrativeInput): string {
+  if (input.special_narrative?.kind === 'early_pedestal_escape') {
+    if (input.special_narrative.exploded) {
+      return `${input.special_narrative.leaver_name} abandona el pedestal antes de tiempo y explota.`;
+    }
+
+    return `${input.special_narrative.leaver_name} abandona el pedestal antes de tiempo, pero no explota.`;
+  }
+
+  const participantsLabel =
+    input.participant_names.length === 0 ? 'sin participantes' : input.participant_names.join(', ');
+  const eliminationSuffix =
+    input.eliminated_names.length > 0
+      ? ` Eliminados: ${input.eliminated_names.join(', ')}.`
+      : ' Nadie fue eliminado.';
+  return `Evento ${input.template_id} en fase ${input.phase} con ${participantsLabel}.${eliminationSuffix}`;
+}

--- a/lib/matches/special-events.ts
+++ b/lib/matches/special-events.ts
@@ -1,0 +1,54 @@
+import { SPECIAL_EVENT_RULES } from '@/lib/domain/rules';
+import type { Match } from '@/lib/domain/types';
+import type { SeededRng } from '@/lib/simulation-state';
+
+export type SpecialEventNarrative =
+  | {
+      kind: 'early_pedestal_escape';
+      leaver_name: string;
+      exploded: boolean;
+    }
+  | undefined;
+
+export type ResolveSpecialEventInput = {
+  phase: Match['cycle_phase'];
+  template_id: string;
+  selected_participants: Array<{
+    id: string;
+    display_name: string;
+  }>;
+  rng: SeededRng;
+};
+
+export type ResolveSpecialEventResult = {
+  handled: boolean;
+  eliminated_participant_ids: string[];
+  narrative: SpecialEventNarrative;
+};
+
+export function resolveSpecialEvent(input: ResolveSpecialEventInput): ResolveSpecialEventResult {
+  const isEarlyPedestalEscape =
+    input.phase === 'bloodbath' &&
+    input.template_id === SPECIAL_EVENT_RULES.early_pedestal_escape.template_id &&
+    input.selected_participants.length > 0;
+
+  if (!isEarlyPedestalEscape) {
+    return {
+      handled: false,
+      eliminated_participant_ids: [],
+      narrative: undefined
+    };
+  }
+
+  const leaver = input.selected_participants[0];
+  const exploded = input.rng() < SPECIAL_EVENT_RULES.early_pedestal_escape.explosion_chance;
+  return {
+    handled: true,
+    eliminated_participant_ids: exploded ? [leaver.id] : [],
+    narrative: {
+      kind: 'early_pedestal_escape',
+      leaver_name: leaver.display_name,
+      exploded
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunger-games",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "packageManager": "pnpm@10.12.4",
   "scripts": {

--- a/tests/lifecycle-early-pedestal.test.ts
+++ b/tests/lifecycle-early-pedestal.test.ts
@@ -1,106 +1,93 @@
 import { describe, expect, it } from 'vitest';
-import {
-  advanceTurn,
-  createMatch,
-  getMatchState,
-  resetMatchesForTests,
-  startMatch
-} from '@/lib/matches/lifecycle';
+import { buildEventNarrative } from '@/lib/matches/event-narrative';
+import { resolveSpecialEvent } from '@/lib/matches/special-events';
 
-const EARLY_EXIT_TEXT = 'abandona el pedestal antes de tiempo';
-
-function roster(size: number): string[] {
-  return Array.from({ length: size }, (_, index) => `char-${index + 1}`);
-}
-
-function simulateFirstTurn(seed: string) {
-  resetMatchesForTests();
-  const created = createMatch({
-    roster_character_ids: roster(10),
-    settings: {
-      surprise_level: 'normal',
-      event_profile: 'balanced',
-      simulation_speed: '1x',
-      seed
-    }
-  });
-
-  const started = startMatch(created.match_id);
-  if (!started.ok) {
-    throw new Error(`Failed to start match for seed "${seed}"`);
-  }
-
-  const advanced = advanceTurn(created.match_id);
-  if (!advanced.ok) {
-    throw new Error(`Failed to advance match for seed "${seed}"`);
-  }
-
-  const state = getMatchState(created.match_id);
-  if (!state) {
-    throw new Error(`Missing state for seed "${seed}"`);
-  }
-
-  const event = state.recent_events[0];
-  return {
-    advanced: advanced.value,
-    event,
-    state
+function rngWith(...rolls: number[]) {
+  let index = 0;
+  return () => {
+    const roll = rolls[Math.min(index, rolls.length - 1)] ?? 0;
+    index += 1;
+    return roll;
   };
 }
 
-function findSeedWithOutcome(predicate: (result: ReturnType<typeof simulateFirstTurn>) => boolean): string {
-  for (let index = 1; index <= 5000; index += 1) {
-    const seed = `issue-56-seed-${index}`;
-    const result = simulateFirstTurn(seed);
-    if (predicate(result)) {
-      return seed;
-    }
-  }
+describe('early pedestal special event resolver', () => {
+  it('eliminates the leaver when explosion roll is below threshold', () => {
+    const result = resolveSpecialEvent({
+      phase: 'bloodbath',
+      template_id: 'hazard-pedestal-early-exit-1',
+      selected_participants: [{ id: 'p1', display_name: 'Tributo Uno' }],
+      rng: rngWith(0.02)
+    });
 
-  throw new Error('No seed found for expected outcome within search window.');
-}
-
-describe('early pedestal explosion rule', () => {
-  it('eliminates the early leaver when explosion triggers', () => {
-    const seed = findSeedWithOutcome(
-      (result) =>
-        result.event.narrative_text.includes(EARLY_EXIT_TEXT) && result.advanced.eliminated_ids.length === 1
-    );
-    const result = simulateFirstTurn(seed);
-
-    expect(result.event.narrative_text).toContain(EARLY_EXIT_TEXT);
-    expect(result.advanced.eliminated_ids).toHaveLength(1);
-    expect(result.advanced.survivors_count).toBe(9);
-    expect(result.event.lethal).toBe(true);
-    expect(result.state.participants.find((participant) => participant.id === result.advanced.eliminated_ids[0]))
-      .toMatchObject({ status: 'eliminated', current_health: 0 });
+    expect(result.handled).toBe(true);
+    expect(result.eliminated_participant_ids).toEqual(['p1']);
+    expect(result.narrative).toEqual({
+      kind: 'early_pedestal_escape',
+      leaver_name: 'Tributo Uno',
+      exploded: true
+    });
   });
 
-  it('keeps the leaver alive when explosion does not trigger', () => {
-    const seed = findSeedWithOutcome(
-      (result) =>
-        result.event.narrative_text.includes(EARLY_EXIT_TEXT) && result.advanced.eliminated_ids.length === 0
-    );
-    const result = simulateFirstTurn(seed);
+  it('keeps the leaver alive when explosion roll is above threshold', () => {
+    const result = resolveSpecialEvent({
+      phase: 'bloodbath',
+      template_id: 'hazard-pedestal-early-exit-1',
+      selected_participants: [{ id: 'p1', display_name: 'Tributo Uno' }],
+      rng: rngWith(0.5)
+    });
 
-    expect(result.event.narrative_text).toContain(EARLY_EXIT_TEXT);
-    expect(result.advanced.eliminated_ids).toEqual([]);
-    expect(result.advanced.survivors_count).toBe(10);
-    expect(result.event.lethal).toBe(false);
+    expect(result.handled).toBe(true);
+    expect(result.eliminated_participant_ids).toEqual([]);
+    expect(result.narrative).toEqual({
+      kind: 'early_pedestal_escape',
+      leaver_name: 'Tributo Uno',
+      exploded: false
+    });
   });
 
-  it('keeps normal bloodbath flow unchanged when event is not early exit', () => {
-    const seed = findSeedWithOutcome(
-      (result) =>
-        !result.event.narrative_text.includes(EARLY_EXIT_TEXT) &&
-        result.event.phase === 'bloodbath' &&
-        result.advanced.turn_number === 1
-    );
-    const result = simulateFirstTurn(seed);
+  it('returns unhandled for non-special templates', () => {
+    const result = resolveSpecialEvent({
+      phase: 'bloodbath',
+      template_id: 'combat-1',
+      selected_participants: [{ id: 'p1', display_name: 'Tributo Uno' }],
+      rng: rngWith(0)
+    });
 
-    expect(result.event.narrative_text).not.toContain(EARLY_EXIT_TEXT);
-    expect(result.advanced.turn_number).toBe(1);
-    expect(result.advanced.cycle_phase).toBe('day');
-    expect(result.advanced.survivors_count).toBe(10 - result.advanced.eliminated_ids.length);
+    expect(result).toEqual({
+      handled: false,
+      eliminated_participant_ids: [],
+      narrative: undefined
+    });
+  });
+});
+
+describe('event narrative builder', () => {
+  it('renders early pedestal narrative from metadata', () => {
+    const narrative = buildEventNarrative({
+      template_id: 'hazard-pedestal-early-exit-1',
+      phase: 'bloodbath',
+      participant_names: ['Tributo Uno'],
+      eliminated_names: ['Tributo Uno'],
+      special_narrative: {
+        kind: 'early_pedestal_escape',
+        leaver_name: 'Tributo Uno',
+        exploded: true
+      }
+    });
+
+    expect(narrative).toBe('Tributo Uno abandona el pedestal antes de tiempo y explota.');
+  });
+
+  it('renders generic narrative independently from special resolver', () => {
+    const narrative = buildEventNarrative({
+      template_id: 'combat-1',
+      phase: 'day',
+      participant_names: ['A', 'B'],
+      eliminated_names: ['B'],
+      special_narrative: undefined
+    });
+
+    expect(narrative).toBe('Evento combat-1 en fase day con A, B. Eliminados: B.');
   });
 });


### PR DESCRIPTION
## Summary
- refactoriza `advanceTurn` para delegar reglas especiales y narrativa
- mueve reglas de evento especial a configuración de dominio versionada
- reemplaza pruebas de búsqueda de seeds por pruebas determinísticas con RNG controlado
- bump SemVer patch a `0.1.2` y actualización de `CHANGELOG.md`

## Validation
- `pnpm run validate`

Closes #61
