### PR TITLE
feat: agregar eventos aleatorios inspirados en películas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-02-23
+
+### Added
+
+- Expand movie-inspired arena event catalog with typed templates for mines, fire waves, toxic fog, muttation hunts, storms, rockslides, sponsor packs, traps, route clashes, risky shelters, Cornucopia refill, and arena escape attempts.
+- Add configurable domain rules for Cornucopia refill activation and elimination-risk boost.
+- Add deterministic tests for movie-event catalog gating, Cornucopia refill, and arena-escape automatic elimination narratives.
+
+### Changed
+
+- Update turn lifecycle to use contextual weighted catalogs and special-event elimination policy (`allow_default_elimination` + `elimination_chance_floor`).
+- Extend special-event resolution to support Cornucopia refill and arena escape events while preserving deterministic RNG behavior.
+
 ## [0.1.2] - 2026-02-23
 
 ### Fixed

--- a/lib/domain/rules.ts
+++ b/lib/domain/rules.ts
@@ -6,6 +6,16 @@ export type SpecialEventRules = {
     template_id: string;
     explosion_chance: number;
   };
+  cornucopia_refill: {
+    template_id: string;
+    min_turn_number: number;
+    max_alive_count: number;
+    activation_weight_multiplier: number;
+    elimination_chance_floor: number;
+  };
+  arena_escape_attempt: {
+    template_id: string;
+  };
 };
 
 export const SPECIAL_EVENT_RULES: SpecialEventRules = {
@@ -13,5 +23,15 @@ export const SPECIAL_EVENT_RULES: SpecialEventRules = {
   early_pedestal_escape: {
     template_id: 'hazard-pedestal-early-exit-1',
     explosion_chance: 0.08
+  },
+  cornucopia_refill: {
+    template_id: 'resource-cornucopia-refill-1',
+    min_turn_number: 4,
+    max_alive_count: 12,
+    activation_weight_multiplier: 1.7,
+    elimination_chance_floor: 0.55
+  },
+  arena_escape_attempt: {
+    template_id: 'hazard-arena-escape-attempt-1'
   }
 };

--- a/lib/matches/event-narrative.ts
+++ b/lib/matches/event-narrative.ts
@@ -17,6 +17,12 @@ export function buildEventNarrative(input: BuildEventNarrativeInput): string {
 
     return `${input.special_narrative.leaver_name} abandona el pedestal antes de tiempo, pero no explota.`;
   }
+  if (input.special_narrative?.kind === 'cornucopia_refill') {
+    return 'El Capitolio anuncia un reabastecimiento en la Cornucopia y los tributos convergen en busca de suministros críticos.';
+  }
+  if (input.special_narrative?.kind === 'arena_escape_attempt') {
+    return `${input.special_narrative.tribune_name} intenta escapar del arena y es ejecutado automáticamente por violar los límites.`;
+  }
 
   const participantsLabel =
     input.participant_names.length === 0 ? 'sin participantes' : input.participant_names.join(', ');

--- a/lib/matches/lifecycle.ts
+++ b/lib/matches/lifecycle.ts
@@ -51,11 +51,33 @@ const MAX_RECENT_EVENTS = 12;
 const TURN_EVENT_CATALOG: EventTemplate[] = [
   { id: 'combat-1', type: 'combat', base_weight: 10, phases: ['bloodbath', 'day', 'night'] },
   { id: 'combat-2', type: 'combat', base_weight: 8, phases: ['bloodbath', 'day', 'night'] },
+  { id: 'hazard-cornucopia-mines-1', type: 'hazard', base_weight: 4, phases: ['bloodbath'] },
   {
     id: SPECIAL_EVENT_RULES.early_pedestal_escape.template_id,
     type: 'hazard',
     base_weight: 3,
     phases: ['bloodbath']
+  },
+  { id: 'hazard-fire-wave-1', type: 'hazard', base_weight: 5, phases: ['day', 'night'] },
+  { id: 'hazard-toxic-fog-1', type: 'hazard', base_weight: 5, phases: ['day', 'night'] },
+  { id: 'surprise-muttation-hunt-1', type: 'surprise', base_weight: 4, phases: ['day', 'night'] },
+  { id: 'hazard-thunderstorm-1', type: 'hazard', base_weight: 4, phases: ['day', 'night'] },
+  { id: 'hazard-rockslide-1', type: 'hazard', base_weight: 3, phases: ['day', 'night', 'finale'] },
+  { id: 'resource-sponsor-pack-1', type: 'resource', base_weight: 5, phases: ['day', 'night'] },
+  { id: 'hazard-quicksand-trap-1', type: 'hazard', base_weight: 3, phases: ['day', 'night'] },
+  { id: 'combat-route-clash-1', type: 'combat', base_weight: 6, phases: ['day', 'night', 'finale'] },
+  { id: 'surprise-risky-shelter-1', type: 'surprise', base_weight: 4, phases: ['night'] },
+  {
+    id: SPECIAL_EVENT_RULES.cornucopia_refill.template_id,
+    type: 'resource',
+    base_weight: 4,
+    phases: ['day', 'night', 'finale']
+  },
+  {
+    id: SPECIAL_EVENT_RULES.arena_escape_attempt.template_id,
+    type: 'hazard',
+    base_weight: 2,
+    phases: ['day', 'night', 'finale']
   },
   { id: 'alliance-1', type: 'alliance', base_weight: 6, phases: ['day', 'night', 'finale'] },
   { id: 'betrayal-1', type: 'betrayal', base_weight: 7, phases: ['day', 'night', 'finale'] },
@@ -127,6 +149,34 @@ function eliminationChance(
   const tensionFactor = tensionLevel / 300;
   const endgameFactor = aliveCount <= 4 ? 0.08 : 0;
   return clamp(phaseBase[cyclePhase] + tensionFactor + endgameFactor, 0, 0.95);
+}
+
+export function isCornucopiaRefillEligible(turnNumber: number, aliveCount: number): boolean {
+  return (
+    turnNumber >= SPECIAL_EVENT_RULES.cornucopia_refill.min_turn_number &&
+    aliveCount <= SPECIAL_EVENT_RULES.cornucopia_refill.max_alive_count
+  );
+}
+
+export function buildContextualTurnCatalog(turnNumber: number, aliveCount: number): EventTemplate[] {
+  return TURN_EVENT_CATALOG.map((template) => {
+    if (template.id === SPECIAL_EVENT_RULES.cornucopia_refill.template_id) {
+      if (!isCornucopiaRefillEligible(turnNumber, aliveCount)) {
+        return {
+          ...template,
+          base_weight: 0
+        };
+      }
+
+      return {
+        ...template,
+        base_weight:
+          template.base_weight * SPECIAL_EVENT_RULES.cornucopia_refill.activation_weight_multiplier
+      };
+    }
+
+    return template;
+  }).filter((template) => template.base_weight > 0);
 }
 
 function resolveWinnerId(participants: ParticipantState[]): string | null {
@@ -339,20 +389,20 @@ export function advanceTurn(matchId: string): AdvanceTurnResult {
   const participantCount = sampleParticipantCount(alive.length, rng);
   const selectedParticipants = chooseParticipants(alive, participantCount, rng);
   const recentTemplateIds = stored.recent_events.slice(-4).map((event) => event.template_id);
+  const contextualCatalog = buildContextualTurnCatalog(nextTurnNumber, alive.length);
   const selectedTemplate = selectCatalogEvent(
-    TURN_EVENT_CATALOG,
+    contextualCatalog,
     currentPhase,
     recentTemplateIds,
     rng,
     2
   );
-  const hadElimination =
-    alive.length > 1 &&
-    (alive.length === 2 || rng() < eliminationChance(currentPhase, stored.match.tension_level, alive.length));
 
   const eliminatedIds: string[] = [];
   const specialResolution = resolveSpecialEvent({
     phase: currentPhase,
+    turn_number: nextTurnNumber,
+    alive_count: alive.length,
     template_id: selectedTemplate.id,
     selected_participants: selectedParticipants.map((participant) => ({
       id: participant.id,
@@ -360,6 +410,12 @@ export function advanceTurn(matchId: string): AdvanceTurnResult {
     })),
     rng
   });
+  const eliminationRollChance = Math.max(
+    eliminationChance(currentPhase, stored.match.tension_level, alive.length),
+    specialResolution.elimination_chance_floor
+  );
+  const hadElimination =
+    alive.length > 1 && (alive.length === 2 || rng() < eliminationRollChance);
 
   for (const eliminatedId of specialResolution.eliminated_participant_ids) {
     eliminatedIds.push(eliminatedId);
@@ -370,7 +426,7 @@ export function advanceTurn(matchId: string): AdvanceTurnResult {
     }
   }
 
-  if (!specialResolution.handled && hadElimination) {
+  if (specialResolution.allow_default_elimination && hadElimination) {
     const eliminatedIndex = Math.floor(rng() * selectedParticipants.length);
     const eliminatedParticipant = selectedParticipants[eliminatedIndex];
     eliminatedIds.push(eliminatedParticipant.id);

--- a/lib/matches/special-events.ts
+++ b/lib/matches/special-events.ts
@@ -8,10 +8,19 @@ export type SpecialEventNarrative =
       leaver_name: string;
       exploded: boolean;
     }
+  | {
+      kind: 'cornucopia_refill';
+    }
+  | {
+      kind: 'arena_escape_attempt';
+      tribune_name: string;
+    }
   | undefined;
 
 export type ResolveSpecialEventInput = {
   phase: Match['cycle_phase'];
+  turn_number: number;
+  alive_count: number;
   template_id: string;
   selected_participants: Array<{
     id: string;
@@ -22,7 +31,9 @@ export type ResolveSpecialEventInput = {
 
 export type ResolveSpecialEventResult = {
   handled: boolean;
+  allow_default_elimination: boolean;
   eliminated_participant_ids: string[];
+  elimination_chance_floor: number;
   narrative: SpecialEventNarrative;
 };
 
@@ -33,9 +44,41 @@ export function resolveSpecialEvent(input: ResolveSpecialEventInput): ResolveSpe
     input.selected_participants.length > 0;
 
   if (!isEarlyPedestalEscape) {
+    const isCornucopiaRefill = input.template_id === SPECIAL_EVENT_RULES.cornucopia_refill.template_id;
+    if (isCornucopiaRefill) {
+      return {
+        handled: true,
+        allow_default_elimination: true,
+        eliminated_participant_ids: [],
+        elimination_chance_floor: SPECIAL_EVENT_RULES.cornucopia_refill.elimination_chance_floor,
+        narrative: {
+          kind: 'cornucopia_refill'
+        }
+      };
+    }
+
+    const isArenaEscapeAttempt =
+      input.template_id === SPECIAL_EVENT_RULES.arena_escape_attempt.template_id &&
+      input.selected_participants.length > 0;
+    if (isArenaEscapeAttempt) {
+      const escapingTribute = input.selected_participants[0];
+      return {
+        handled: true,
+        allow_default_elimination: false,
+        eliminated_participant_ids: [escapingTribute.id],
+        elimination_chance_floor: 0,
+        narrative: {
+          kind: 'arena_escape_attempt',
+          tribune_name: escapingTribute.display_name
+        }
+      };
+    }
+
     return {
       handled: false,
+      allow_default_elimination: true,
       eliminated_participant_ids: [],
+      elimination_chance_floor: 0,
       narrative: undefined
     };
   }
@@ -44,7 +87,9 @@ export function resolveSpecialEvent(input: ResolveSpecialEventInput): ResolveSpe
   const exploded = input.rng() < SPECIAL_EVENT_RULES.early_pedestal_escape.explosion_chance;
   return {
     handled: true,
+    allow_default_elimination: false,
     eliminated_participant_ids: exploded ? [leaver.id] : [],
+    elimination_chance_floor: 0,
     narrative: {
       kind: 'early_pedestal_escape',
       leaver_name: leaver.display_name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunger-games",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "packageManager": "pnpm@10.12.4",
   "scripts": {

--- a/tests/lifecycle-early-pedestal.test.ts
+++ b/tests/lifecycle-early-pedestal.test.ts
@@ -15,12 +15,16 @@ describe('early pedestal special event resolver', () => {
   it('eliminates the leaver when explosion roll is below threshold', () => {
     const result = resolveSpecialEvent({
       phase: 'bloodbath',
+      turn_number: 1,
+      alive_count: 24,
       template_id: 'hazard-pedestal-early-exit-1',
       selected_participants: [{ id: 'p1', display_name: 'Tributo Uno' }],
       rng: rngWith(0.02)
     });
 
     expect(result.handled).toBe(true);
+    expect(result.allow_default_elimination).toBe(false);
+    expect(result.elimination_chance_floor).toBe(0);
     expect(result.eliminated_participant_ids).toEqual(['p1']);
     expect(result.narrative).toEqual({
       kind: 'early_pedestal_escape',
@@ -32,12 +36,16 @@ describe('early pedestal special event resolver', () => {
   it('keeps the leaver alive when explosion roll is above threshold', () => {
     const result = resolveSpecialEvent({
       phase: 'bloodbath',
+      turn_number: 1,
+      alive_count: 24,
       template_id: 'hazard-pedestal-early-exit-1',
       selected_participants: [{ id: 'p1', display_name: 'Tributo Uno' }],
       rng: rngWith(0.5)
     });
 
     expect(result.handled).toBe(true);
+    expect(result.allow_default_elimination).toBe(false);
+    expect(result.elimination_chance_floor).toBe(0);
     expect(result.eliminated_participant_ids).toEqual([]);
     expect(result.narrative).toEqual({
       kind: 'early_pedestal_escape',
@@ -49,6 +57,8 @@ describe('early pedestal special event resolver', () => {
   it('returns unhandled for non-special templates', () => {
     const result = resolveSpecialEvent({
       phase: 'bloodbath',
+      turn_number: 1,
+      alive_count: 24,
       template_id: 'combat-1',
       selected_participants: [{ id: 'p1', display_name: 'Tributo Uno' }],
       rng: rngWith(0)
@@ -56,8 +66,53 @@ describe('early pedestal special event resolver', () => {
 
     expect(result).toEqual({
       handled: false,
+      allow_default_elimination: true,
       eliminated_participant_ids: [],
+      elimination_chance_floor: 0,
       narrative: undefined
+    });
+  });
+
+  it('boosts elimination chance for cornucopia refill without forced kill', () => {
+    const result = resolveSpecialEvent({
+      phase: 'day',
+      turn_number: 5,
+      alive_count: 10,
+      template_id: 'resource-cornucopia-refill-1',
+      selected_participants: [{ id: 'p1', display_name: 'Tributo Uno' }],
+      rng: rngWith(0.9)
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      allow_default_elimination: true,
+      eliminated_participant_ids: [],
+      elimination_chance_floor: 0.55,
+      narrative: {
+        kind: 'cornucopia_refill'
+      }
+    });
+  });
+
+  it('eliminates tribute automatically on arena escape attempt', () => {
+    const result = resolveSpecialEvent({
+      phase: 'night',
+      turn_number: 7,
+      alive_count: 8,
+      template_id: 'hazard-arena-escape-attempt-1',
+      selected_participants: [{ id: 'p1', display_name: 'Katniss' }],
+      rng: rngWith(0.5)
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      allow_default_elimination: false,
+      eliminated_participant_ids: ['p1'],
+      elimination_chance_floor: 0,
+      narrative: {
+        kind: 'arena_escape_attempt',
+        tribune_name: 'Katniss'
+      }
     });
   });
 });
@@ -89,5 +144,35 @@ describe('event narrative builder', () => {
     });
 
     expect(narrative).toBe('Evento combat-1 en fase day con A, B. Eliminados: B.');
+  });
+
+  it('renders cornucopia refill narrative', () => {
+    const narrative = buildEventNarrative({
+      template_id: 'resource-cornucopia-refill-1',
+      phase: 'day',
+      participant_names: ['A', 'B'],
+      eliminated_names: [],
+      special_narrative: {
+        kind: 'cornucopia_refill'
+      }
+    });
+
+    expect(narrative).toContain('reabastecimiento en la Cornucopia');
+  });
+
+  it('renders arena escape narrative', () => {
+    const narrative = buildEventNarrative({
+      template_id: 'hazard-arena-escape-attempt-1',
+      phase: 'night',
+      participant_names: ['Katniss'],
+      eliminated_names: ['Katniss'],
+      special_narrative: {
+        kind: 'arena_escape_attempt',
+        tribune_name: 'Katniss'
+      }
+    });
+
+    expect(narrative).toContain('intenta escapar del arena');
+    expect(narrative).toContain('ejecutado automáticamente');
   });
 });

--- a/tests/lifecycle-movie-events.test.ts
+++ b/tests/lifecycle-movie-events.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { buildContextualTurnCatalog, isCornucopiaRefillEligible } from '@/lib/matches/lifecycle';
+
+describe('movie-inspired turn event catalog', () => {
+  it('enables cornucopia refill only when configured turn/alive thresholds are met', () => {
+    expect(isCornucopiaRefillEligible(3, 12)).toBe(false);
+    expect(isCornucopiaRefillEligible(4, 13)).toBe(false);
+    expect(isCornucopiaRefillEligible(4, 12)).toBe(true);
+  });
+
+  it('includes cinematic templates and gates cornucopia refill before threshold', () => {
+    const earlyCatalog = buildContextualTurnCatalog(2, 20);
+    const enabledCatalog = buildContextualTurnCatalog(6, 10);
+
+    expect(earlyCatalog.some((template) => template.id === 'resource-cornucopia-refill-1')).toBe(false);
+    expect(enabledCatalog.some((template) => template.id === 'resource-cornucopia-refill-1')).toBe(true);
+    expect(enabledCatalog.some((template) => template.id === 'hazard-arena-escape-attempt-1')).toBe(true);
+    expect(enabledCatalog.some((template) => template.id === 'hazard-toxic-fog-1')).toBe(true);
+    expect(enabledCatalog.some((template) => template.id === 'surprise-muttation-hunt-1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Resumen
- amplía el catálogo tipado de eventos con eventos cinematográficos (minas, fuego, niebla tóxica, mutts, tormenta, derrumbe, trampas, refugio, cornucopia refill y escape de arena)
- incorpora reglas configurables de cornucopia_refill y arena_escape_attempt en lib/domain/rules.ts
- aplica lógica especial de riesgo y eliminación automática con narrativa explícita
- mantiene contratos API y agrega pruebas deterministas para resolver eventos especiales y catálogo contextual
- bump de versión a 0.2.0 y actualización de CHANGELOG.md

## Validación
- pnpm run validate

Closes #43
