### PR TITLE
feat: agregar locations tipadas en eventos de simulacion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-02-23
+
+### Added
+
+- Add typed arena location catalog (`cornucopia`, `forest`, `river`, `lake`, `meadow`, `caves`, `ruins`, `cliffs`) and expose it as a first-class event contract field.
+- Include `location` in generated turn events, match snapshots, and `advance_turn` responses.
+- Add deterministic location preferences in the event template catalog so themed events happen in coherent places.
+
+### Changed
+
+- Update event narrative builder to always mention where the event occurred, including special-event narratives.
+- Extend domain schemas/contracts and tests so every event now requires a valid typed `location`.
+
 ## [0.2.0] - 2026-02-23
 
 ### Added

--- a/lib/domain/event-locations.ts
+++ b/lib/domain/event-locations.ts
@@ -1,0 +1,23 @@
+import type { EventLocation } from '@/lib/domain/types';
+
+export const EVENT_LOCATION_CATALOG: readonly EventLocation[] = [
+  'cornucopia',
+  'forest',
+  'river',
+  'lake',
+  'meadow',
+  'caves',
+  'ruins',
+  'cliffs'
+] as const;
+
+export const EVENT_LOCATION_LABEL: Record<EventLocation, string> = {
+  cornucopia: 'la Cornucopia',
+  forest: 'el bosque',
+  river: 'el rio',
+  lake: 'el lago',
+  meadow: 'la pradera',
+  caves: 'las cuevas',
+  ruins: 'las ruinas',
+  cliffs: 'los acantilados'
+};

--- a/lib/domain/schemas.ts
+++ b/lib/domain/schemas.ts
@@ -15,6 +15,16 @@ export const eventTypeSchema = z.enum([
   'hazard',
   'surprise'
 ]);
+export const eventLocationSchema = z.enum([
+  'cornucopia',
+  'forest',
+  'river',
+  'lake',
+  'meadow',
+  'caves',
+  'ruins',
+  'cliffs'
+]);
 export const eventParticipantRoleSchema = z.enum([
   'initiator',
   'target',
@@ -55,6 +65,7 @@ export const eventSchema = z
     template_id: z.string().min(1),
     turn_number: z.number().int().min(0),
     type: eventTypeSchema,
+    location: eventLocationSchema,
     phase: cyclePhaseSchema,
     participant_count: z.number().int().min(0),
     intensity: z.number().min(0),
@@ -172,6 +183,7 @@ export const advanceTurnResponseSchema = z
       .object({
         id: z.string().min(1),
         type: eventTypeSchema,
+        location: eventLocationSchema,
         phase: cyclePhaseSchema,
         narrative_text: z.string().min(1),
         participant_ids: z.array(z.string().min(1)).min(1)

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -14,6 +14,15 @@ export type EventType =
   | 'resource'
   | 'hazard'
   | 'surprise';
+export type EventLocation =
+  | 'cornucopia'
+  | 'forest'
+  | 'river'
+  | 'lake'
+  | 'meadow'
+  | 'caves'
+  | 'ruins'
+  | 'cliffs';
 export type EventParticipantRole = 'initiator' | 'target' | 'ally' | 'observer';
 export type ValidationIssue = {
   path: Array<string | number>;
@@ -68,6 +77,7 @@ export type Event = {
   template_id: string;
   turn_number: number;
   type: EventType;
+  location: EventLocation;
   phase: CyclePhase;
   participant_count: number;
   intensity: number;
@@ -113,6 +123,7 @@ export type StartMatchResponse = {
 export type AdvanceTurnEventResponse = {
   id: string;
   type: EventType;
+  location: EventLocation;
   phase: CyclePhase;
   narrative_text: string;
   participant_ids: string[];

--- a/lib/matches/event-narrative.ts
+++ b/lib/matches/event-narrative.ts
@@ -1,8 +1,10 @@
-import type { Match } from '@/lib/domain/types';
+import { EVENT_LOCATION_LABEL } from '@/lib/domain/event-locations';
+import type { EventLocation, Match } from '@/lib/domain/types';
 import type { SpecialEventNarrative } from '@/lib/matches/special-events';
 
 type BuildEventNarrativeInput = {
   template_id: string;
+  location: EventLocation;
   phase: Match['cycle_phase'];
   participant_names: string[];
   eliminated_names: string[];
@@ -10,18 +12,20 @@ type BuildEventNarrativeInput = {
 };
 
 export function buildEventNarrative(input: BuildEventNarrativeInput): string {
+  const locationLabel = EVENT_LOCATION_LABEL[input.location];
+
   if (input.special_narrative?.kind === 'early_pedestal_escape') {
     if (input.special_narrative.exploded) {
-      return `${input.special_narrative.leaver_name} abandona el pedestal antes de tiempo y explota.`;
+      return `${input.special_narrative.leaver_name} abandona el pedestal antes de tiempo en ${locationLabel} y explota.`;
     }
 
-    return `${input.special_narrative.leaver_name} abandona el pedestal antes de tiempo, pero no explota.`;
+    return `${input.special_narrative.leaver_name} abandona el pedestal antes de tiempo en ${locationLabel}, pero no explota.`;
   }
   if (input.special_narrative?.kind === 'cornucopia_refill') {
     return 'El Capitolio anuncia un reabastecimiento en la Cornucopia y los tributos convergen en busca de suministros críticos.';
   }
   if (input.special_narrative?.kind === 'arena_escape_attempt') {
-    return `${input.special_narrative.tribune_name} intenta escapar del arena y es ejecutado automáticamente por violar los límites.`;
+    return `${input.special_narrative.tribune_name} intenta escapar del arena en ${locationLabel} y es ejecutado automáticamente por violar los límites.`;
   }
 
   const participantsLabel =
@@ -30,5 +34,5 @@ export function buildEventNarrative(input: BuildEventNarrativeInput): string {
     input.eliminated_names.length > 0
       ? ` Eliminados: ${input.eliminated_names.join(', ')}.`
       : ' Nadie fue eliminado.';
-  return `Evento ${input.template_id} en fase ${input.phase} con ${participantsLabel}.${eliminationSuffix}`;
+  return `Evento ${input.template_id} en ${locationLabel} durante ${input.phase} con ${participantsLabel}.${eliminationSuffix}`;
 }

--- a/lib/simulation-state.ts
+++ b/lib/simulation-state.ts
@@ -4,7 +4,7 @@ export type MatchState = {
   active: boolean;
 };
 
-import type { CyclePhase, EventType } from '@/lib/domain/types';
+import type { CyclePhase, EventLocation, EventType } from '@/lib/domain/types';
 
 const MAX_MULTI_PARTICIPANT_CHANCE = 0.02;
 const DEFAULT_SEEDED_RNG_SEED = 'hunger-games-default-seed';
@@ -23,6 +23,7 @@ export type EventTemplate = {
   type: EventType;
   base_weight: number;
   phases: CyclePhase[];
+  preferred_locations?: readonly EventLocation[];
 };
 
 function normalizeSeed(seed: string | null | undefined): string {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunger-games",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.12.4",
   "scripts": {

--- a/tests/domain-contracts.test.ts
+++ b/tests/domain-contracts.test.ts
@@ -196,6 +196,7 @@ describe('match lifecycle response contracts', () => {
       event: {
         id: 'event-1',
         type: 'combat',
+        location: 'forest',
         phase: 'bloodbath',
         narrative_text: 'Evento combat-1 en fase bloodbath con 2 participante(s). Hubo 1 eliminacion.',
         participant_ids: ['participant-1', 'participant-2']

--- a/tests/lifecycle-early-pedestal.test.ts
+++ b/tests/lifecycle-early-pedestal.test.ts
@@ -121,6 +121,7 @@ describe('event narrative builder', () => {
   it('renders early pedestal narrative from metadata', () => {
     const narrative = buildEventNarrative({
       template_id: 'hazard-pedestal-early-exit-1',
+      location: 'cornucopia',
       phase: 'bloodbath',
       participant_names: ['Tributo Uno'],
       eliminated_names: ['Tributo Uno'],
@@ -131,24 +132,28 @@ describe('event narrative builder', () => {
       }
     });
 
-    expect(narrative).toBe('Tributo Uno abandona el pedestal antes de tiempo y explota.');
+    expect(narrative).toBe(
+      'Tributo Uno abandona el pedestal antes de tiempo en la Cornucopia y explota.'
+    );
   });
 
   it('renders generic narrative independently from special resolver', () => {
     const narrative = buildEventNarrative({
       template_id: 'combat-1',
+      location: 'forest',
       phase: 'day',
       participant_names: ['A', 'B'],
       eliminated_names: ['B'],
       special_narrative: undefined
     });
 
-    expect(narrative).toBe('Evento combat-1 en fase day con A, B. Eliminados: B.');
+    expect(narrative).toBe('Evento combat-1 en el bosque durante day con A, B. Eliminados: B.');
   });
 
   it('renders cornucopia refill narrative', () => {
     const narrative = buildEventNarrative({
       template_id: 'resource-cornucopia-refill-1',
+      location: 'cornucopia',
       phase: 'day',
       participant_names: ['A', 'B'],
       eliminated_names: [],
@@ -163,6 +168,7 @@ describe('event narrative builder', () => {
   it('renders arena escape narrative', () => {
     const narrative = buildEventNarrative({
       template_id: 'hazard-arena-escape-attempt-1',
+      location: 'cliffs',
       phase: 'night',
       participant_names: ['Katniss'],
       eliminated_names: ['Katniss'],


### PR DESCRIPTION
## Summary
- add typed arena location catalog and include `location` in event domain contracts
- assign coherent event locations during turn generation and return location in `advance_turn`
- update event narratives to always mention where each event happened
- update contract and narrative tests plus bump version/changelog for review

## Validation
- pnpm run validate

Closes #42
