### PR TITLE
feat: selección de roster por franquicia/películas populares (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-02-24
+
+### Added
+
+- Add explicit franchise catalog diagnostics for invalid `version` (`invalid_version_count`) to avoid silent acceptance in normalization flows.
+
+### Changed
+
+- Harden `createMatchRequest` API contract to reject duplicated `roster_character_ids`, preventing direct-client bypass of anti-duplication guarantees.
+
+### Fixed
+
+- Resolve issue #78 by enforcing explicit handling of invalid franchise catalog `version` while preserving compatibility with valid `version: 1`.
+
 ## [0.4.0] - 2026-02-23
 
 ### Added

--- a/app/matches/new/page.module.css
+++ b/app/matches/new/page.module.css
@@ -186,6 +186,25 @@
   grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
 }
 
+.catalogSetup {
+  display: grid;
+  gap: 12px;
+}
+
+.catalogSelectionGrid {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.movieGrid {
+  margin-top: 8px;
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
 .characterToggle {
   display: flex;
   align-items: center;
@@ -247,6 +266,11 @@
 
 .buttonGhost {
   background: #fff;
+}
+
+.buttonSelected {
+  background: linear-gradient(180deg, #f6b157, #e5861f);
+  color: #2f1e10;
 }
 
 .eventShell {

--- a/lib/domain/franchise-catalog.ts
+++ b/lib/domain/franchise-catalog.ts
@@ -1,0 +1,295 @@
+import { franchiseCatalogSchema } from '@/lib/domain/schemas';
+import type { FranchiseCatalog, FranchiseCharacter } from '@/lib/domain/types';
+
+export type FranchiseMovie = {
+  movie_id: string;
+  movie_title: string;
+  franchise_id: string;
+  franchise_name: string;
+};
+
+export const DEFAULT_FRANCHISE_CATALOG_SOURCE: FranchiseCatalog = {
+  version: 1,
+  franchises: [
+    {
+      franchise_id: 'sw',
+      franchise_name: 'Star Wars'
+    },
+    {
+      franchise_id: 'mcu',
+      franchise_name: 'Marvel Cinematic Universe'
+    },
+    {
+      franchise_id: 'hp',
+      franchise_name: 'Harry Potter'
+    }
+  ],
+  characters: [
+    { character_key: 'sw-luke', display_name: 'Luke Skywalker', franchise_id: 'sw', movie_id: 'sw-anh', movie_title: 'A New Hope' },
+    { character_key: 'sw-leia', display_name: 'Leia Organa', franchise_id: 'sw', movie_id: 'sw-anh', movie_title: 'A New Hope' },
+    { character_key: 'sw-han', display_name: 'Han Solo', franchise_id: 'sw', movie_id: 'sw-anh', movie_title: 'A New Hope' },
+    { character_key: 'sw-vader', display_name: 'Darth Vader', franchise_id: 'sw', movie_id: 'sw-anh', movie_title: 'A New Hope' },
+    { character_key: 'sw-r2d2', display_name: 'R2-D2', franchise_id: 'sw', movie_id: 'sw-anh', movie_title: 'A New Hope' },
+    { character_key: 'sw-c3po', display_name: 'C-3PO', franchise_id: 'sw', movie_id: 'sw-anh', movie_title: 'A New Hope' },
+    { character_key: 'sw-yoda', display_name: 'Yoda', franchise_id: 'sw', movie_id: 'sw-esb', movie_title: 'The Empire Strikes Back' },
+    { character_key: 'sw-lando', display_name: 'Lando Calrissian', franchise_id: 'sw', movie_id: 'sw-esb', movie_title: 'The Empire Strikes Back' },
+    { character_key: 'sw-boba', display_name: 'Boba Fett', franchise_id: 'sw', movie_id: 'sw-esb', movie_title: 'The Empire Strikes Back' },
+    { character_key: 'sw-chewie', display_name: 'Chewbacca', franchise_id: 'sw', movie_id: 'sw-esb', movie_title: 'The Empire Strikes Back' },
+    { character_key: 'sw-piett', display_name: 'Admiral Piett', franchise_id: 'sw', movie_id: 'sw-esb', movie_title: 'The Empire Strikes Back' },
+    { character_key: 'sw-ig88', display_name: 'IG-88', franchise_id: 'sw', movie_id: 'sw-esb', movie_title: 'The Empire Strikes Back' },
+    { character_key: 'mcu-tony', display_name: 'Tony Stark', franchise_id: 'mcu', movie_id: 'mcu-avengers', movie_title: 'The Avengers' },
+    { character_key: 'mcu-steve', display_name: 'Steve Rogers', franchise_id: 'mcu', movie_id: 'mcu-avengers', movie_title: 'The Avengers' },
+    { character_key: 'mcu-thor', display_name: 'Thor', franchise_id: 'mcu', movie_id: 'mcu-avengers', movie_title: 'The Avengers' },
+    { character_key: 'mcu-natasha', display_name: 'Natasha Romanoff', franchise_id: 'mcu', movie_id: 'mcu-avengers', movie_title: 'The Avengers' },
+    { character_key: 'mcu-clint', display_name: 'Clint Barton', franchise_id: 'mcu', movie_id: 'mcu-avengers', movie_title: 'The Avengers' },
+    { character_key: 'mcu-hulk', display_name: 'Bruce Banner', franchise_id: 'mcu', movie_id: 'mcu-avengers', movie_title: 'The Avengers' },
+    { character_key: 'mcu-peter', display_name: 'Peter Parker', franchise_id: 'mcu', movie_id: 'mcu-civil-war', movie_title: 'Captain America: Civil War' },
+    { character_key: 'mcu-tchalla', display_name: "T'Challa", franchise_id: 'mcu', movie_id: 'mcu-civil-war', movie_title: 'Captain America: Civil War' },
+    { character_key: 'mcu-wanda', display_name: 'Wanda Maximoff', franchise_id: 'mcu', movie_id: 'mcu-civil-war', movie_title: 'Captain America: Civil War' },
+    { character_key: 'mcu-sam', display_name: 'Sam Wilson', franchise_id: 'mcu', movie_id: 'mcu-civil-war', movie_title: 'Captain America: Civil War' },
+    { character_key: 'mcu-bucky', display_name: 'Bucky Barnes', franchise_id: 'mcu', movie_id: 'mcu-civil-war', movie_title: 'Captain America: Civil War' },
+    { character_key: 'mcu-vision', display_name: 'Vision', franchise_id: 'mcu', movie_id: 'mcu-civil-war', movie_title: 'Captain America: Civil War' },
+    { character_key: 'hp-harry', display_name: 'Harry Potter', franchise_id: 'hp', movie_id: 'hp-ss', movie_title: "Harry Potter and the Sorcerer's Stone" },
+    { character_key: 'hp-hermione', display_name: 'Hermione Granger', franchise_id: 'hp', movie_id: 'hp-ss', movie_title: "Harry Potter and the Sorcerer's Stone" },
+    { character_key: 'hp-ron', display_name: 'Ron Weasley', franchise_id: 'hp', movie_id: 'hp-ss', movie_title: "Harry Potter and the Sorcerer's Stone" },
+    { character_key: 'hp-dumbledore', display_name: 'Albus Dumbledore', franchise_id: 'hp', movie_id: 'hp-ss', movie_title: "Harry Potter and the Sorcerer's Stone" },
+    { character_key: 'hp-snape', display_name: 'Severus Snape', franchise_id: 'hp', movie_id: 'hp-ss', movie_title: "Harry Potter and the Sorcerer's Stone" },
+    { character_key: 'hp-draco', display_name: 'Draco Malfoy', franchise_id: 'hp', movie_id: 'hp-ss', movie_title: "Harry Potter and the Sorcerer's Stone" },
+    { character_key: 'hp-neville', display_name: 'Neville Longbottom', franchise_id: 'hp', movie_id: 'hp-dh2', movie_title: 'Harry Potter and the Deathly Hallows: Part 2' },
+    { character_key: 'hp-luna', display_name: 'Luna Lovegood', franchise_id: 'hp', movie_id: 'hp-dh2', movie_title: 'Harry Potter and the Deathly Hallows: Part 2' },
+    { character_key: 'hp-minerva', display_name: 'Minerva McGonagall', franchise_id: 'hp', movie_id: 'hp-dh2', movie_title: 'Harry Potter and the Deathly Hallows: Part 2' },
+    { character_key: 'hp-molly', display_name: 'Molly Weasley', franchise_id: 'hp', movie_id: 'hp-dh2', movie_title: 'Harry Potter and the Deathly Hallows: Part 2' },
+    { character_key: 'hp-voldemort', display_name: 'Lord Voldemort', franchise_id: 'hp', movie_id: 'hp-dh2', movie_title: 'Harry Potter and the Deathly Hallows: Part 2' },
+    { character_key: 'hp-bellatrix', display_name: 'Bellatrix Lestrange', franchise_id: 'hp', movie_id: 'hp-dh2', movie_title: 'Harry Potter and the Deathly Hallows: Part 2' }
+  ]
+};
+
+export type FranchiseCatalogDiagnostics = {
+  duplicate_character_key_count: number;
+  dropped_character_count: number;
+  invalid_entry_count: number;
+  invalid_version_count: number;
+};
+
+export type NormalizeFranchiseCatalogResult = {
+  catalog: FranchiseCatalog;
+  diagnostics: FranchiseCatalogDiagnostics;
+};
+
+function emptyCatalog(): FranchiseCatalog {
+  return {
+    version: 1,
+    franchises: [],
+    characters: []
+  };
+}
+
+export function normalizeFranchiseCatalog(input: unknown): NormalizeFranchiseCatalogResult {
+  const parsedInput = franchiseCatalogSchema.safeParse(input);
+  if (parsedInput.success) {
+    return {
+      catalog: parsedInput.data,
+      diagnostics: {
+        duplicate_character_key_count: 0,
+        dropped_character_count: 0,
+        invalid_entry_count: 0,
+        invalid_version_count: 0
+      }
+    };
+  }
+
+  if (!input || typeof input !== 'object') {
+    return {
+      catalog: emptyCatalog(),
+      diagnostics: {
+        duplicate_character_key_count: 0,
+        dropped_character_count: 0,
+        invalid_entry_count: 1,
+        invalid_version_count: 0
+      }
+    };
+  }
+
+  const raw = input as {
+    version?: unknown;
+    franchises?: unknown;
+    characters?: unknown;
+  };
+
+  const franchises = Array.isArray(raw.franchises) ? raw.franchises : [];
+  const franchiseIds = new Set<string>();
+  const safeFranchises = franchises
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const candidate = entry as { franchise_id?: unknown; franchise_name?: unknown };
+      if (typeof candidate.franchise_id !== 'string' || typeof candidate.franchise_name !== 'string') {
+        return null;
+      }
+      const franchise_id = candidate.franchise_id.trim();
+      const franchise_name = candidate.franchise_name.trim();
+      if (franchise_id.length === 0 || franchise_name.length === 0 || franchiseIds.has(franchise_id)) {
+        return null;
+      }
+      franchiseIds.add(franchise_id);
+      return { franchise_id, franchise_name };
+    })
+    .filter((entry): entry is FranchiseCatalog['franchises'][number] => entry !== null);
+
+  const characters = Array.isArray(raw.characters) ? raw.characters : [];
+  const characterKeys = new Set<string>();
+  let duplicateCharacterKeyCount = 0;
+  let invalidEntryCount = 0;
+  const invalidVersionCount = raw.version === 1 ? 0 : 1;
+  const safeCharacters: FranchiseCharacter[] = [];
+
+  for (const entry of characters) {
+    if (!entry || typeof entry !== 'object') {
+      invalidEntryCount += 1;
+      continue;
+    }
+    const candidate = entry as Record<string, unknown>;
+    const character_key =
+      typeof candidate.character_key === 'string' ? candidate.character_key.trim() : '';
+    const display_name =
+      typeof candidate.display_name === 'string' ? candidate.display_name.trim() : '';
+    const franchise_id =
+      typeof candidate.franchise_id === 'string' ? candidate.franchise_id.trim() : '';
+    const movie_id = typeof candidate.movie_id === 'string' ? candidate.movie_id.trim() : '';
+    const movie_title =
+      typeof candidate.movie_title === 'string' ? candidate.movie_title.trim() : '';
+
+    if (
+      character_key.length === 0 ||
+      display_name.length === 0 ||
+      franchise_id.length === 0 ||
+      movie_id.length === 0 ||
+      movie_title.length === 0
+    ) {
+      invalidEntryCount += 1;
+      continue;
+    }
+
+    if (!franchiseIds.has(franchise_id)) {
+      invalidEntryCount += 1;
+      continue;
+    }
+
+    if (characterKeys.has(character_key)) {
+      duplicateCharacterKeyCount += 1;
+      continue;
+    }
+
+    characterKeys.add(character_key);
+    safeCharacters.push({
+      character_key,
+      display_name,
+      franchise_id,
+      movie_id,
+      movie_title,
+      aliases: Array.isArray(candidate.aliases)
+        ? candidate.aliases.filter((alias): alias is string => typeof alias === 'string').map((alias) => alias.trim()).filter((alias) => alias.length > 0)
+        : undefined
+    });
+  }
+
+  const normalized = {
+    version: raw.version === 1 ? 1 : 1,
+    franchises: safeFranchises,
+    characters: safeCharacters
+  } as const;
+
+  const parsedNormalized = franchiseCatalogSchema.safeParse(normalized);
+  const droppedCharacterCount = Math.max(0, characters.length - safeCharacters.length);
+  if (!parsedNormalized.success) {
+    return {
+      catalog: emptyCatalog(),
+      diagnostics: {
+        duplicate_character_key_count: duplicateCharacterKeyCount,
+        dropped_character_count: droppedCharacterCount,
+        invalid_entry_count: invalidEntryCount + 1,
+        invalid_version_count: invalidVersionCount
+      }
+    };
+  }
+
+  return {
+    catalog: parsedNormalized.data,
+    diagnostics: {
+      duplicate_character_key_count: duplicateCharacterKeyCount,
+      dropped_character_count: droppedCharacterCount,
+      invalid_entry_count: invalidEntryCount,
+      invalid_version_count: invalidVersionCount
+    }
+  };
+}
+
+export function buildCharacterLabel(
+  character: Pick<FranchiseCharacter, 'display_name' | 'movie_title'>,
+  hasNameCollision: boolean
+): string {
+  if (!hasNameCollision) {
+    return character.display_name;
+  }
+
+  return `${character.display_name} · ${character.movie_title}`;
+}
+
+export function listFranchiseMovies(
+  catalog: FranchiseCatalog,
+  franchiseId: string
+): FranchiseMovie[] {
+  const franchise = catalog.franchises.find((entry) => entry.franchise_id === franchiseId);
+  if (!franchise) {
+    return [];
+  }
+
+  const byMovieId = new Map<string, FranchiseMovie>();
+  for (const character of catalog.characters) {
+    if (character.franchise_id !== franchiseId || byMovieId.has(character.movie_id)) {
+      continue;
+    }
+    byMovieId.set(character.movie_id, {
+      movie_id: character.movie_id,
+      movie_title: character.movie_title,
+      franchise_id: franchise.franchise_id,
+      franchise_name: franchise.franchise_name
+    });
+  }
+
+  return [...byMovieId.values()].sort((left, right) =>
+    left.movie_title.localeCompare(right.movie_title)
+  );
+}
+
+export function buildRosterFromMovieSelection(
+  catalog: FranchiseCatalog,
+  franchiseId: string | null,
+  movieIds: string[]
+): string[] {
+  if (!franchiseId || movieIds.length === 0) {
+    return [];
+  }
+
+  const selectedMovieIds = new Set(movieIds);
+  const seenCharacterIds = new Set<string>();
+  const roster: string[] = [];
+
+  for (const character of catalog.characters) {
+    if (character.franchise_id !== franchiseId) {
+      continue;
+    }
+    if (!selectedMovieIds.has(character.movie_id)) {
+      continue;
+    }
+    if (seenCharacterIds.has(character.character_key)) {
+      continue;
+    }
+
+    seenCharacterIds.add(character.character_key);
+    roster.push(character.character_key);
+  }
+
+  return roster;
+}

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -52,6 +52,28 @@ export type MatchSettings = {
   seed: string | null;
 };
 
+export type FranchiseCatalogVersion = 1;
+
+export type FranchiseEntry = {
+  franchise_id: string;
+  franchise_name: string;
+};
+
+export type FranchiseCharacter = {
+  character_key: string;
+  display_name: string;
+  franchise_id: string;
+  movie_id: string;
+  movie_title: string;
+  aliases?: string[];
+};
+
+export type FranchiseCatalog = {
+  version: FranchiseCatalogVersion;
+  franchises: FranchiseEntry[];
+  characters: FranchiseCharacter[];
+};
+
 export type Match = {
   id: string;
   seed: string | null;

--- a/lib/local-matches.ts
+++ b/lib/local-matches.ts
@@ -217,6 +217,7 @@ function parseLocalMatchesWithDiagnostics(raw: string | null): LocalMatchesParse
 
 export function getSetupValidation(rosterCharacterIds: string[]): SetupValidation {
   const issues: string[] = [];
+  const uniqueRosterSize = new Set(rosterCharacterIds).size;
 
   if (rosterCharacterIds.length < MIN_ROSTER_SIZE) {
     issues.push(`Selecciona al menos ${MIN_ROSTER_SIZE} personajes.`);
@@ -224,6 +225,10 @@ export function getSetupValidation(rosterCharacterIds: string[]): SetupValidatio
 
   if (rosterCharacterIds.length > MAX_ROSTER_SIZE) {
     issues.push(`No puedes seleccionar mas de ${MAX_ROSTER_SIZE} personajes.`);
+  }
+
+  if (uniqueRosterSize !== rosterCharacterIds.length) {
+    issues.push('No puedes repetir personajes en el roster.');
   }
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunger-games",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "packageManager": "pnpm@10.12.4",
   "scripts": {

--- a/specs/issue-78-franchise-catalog-anti-duplicado.md
+++ b/specs/issue-78-franchise-catalog-anti-duplicado.md
@@ -1,0 +1,159 @@
+# Issue #78 - Catalogo de franquicias con anti-duplicado y UX de estado vacio
+
+## Estado
+- Issue: #78
+- Tipo: Feature funcional con ajuste de dominio liviano
+- Prioridad: P1
+- Ownership actual: review-spec
+- Next handoff: implementation
+
+## Contexto
+Se requiere habilitar seleccion de roster basada en franquicias (pelicula/personaje) sin introducir duplicados ni ambiguedad para el usuario.
+
+Riesgo principal identificado en triage:
+- Ambiguedad pelicula/personaje (mismo nombre de personaje en peliculas distintas o misma franquicia con multiples entregas).
+
+Condicion de entrega del triage:
+- Contrato interno `FranchiseCatalog` cerrado.
+- Reglas anti-duplicado cerradas.
+- UX definida para estado vacio del catalogo.
+- Compatibilidad con snapshots actuales de `localStorage`.
+- Matriz minima de pruebas para no-regresion.
+
+## Objetivo
+Introducir seleccion de roster por catalogo de franquicias con identidad canonica por personaje, evitando duplicados ambiguos y manteniendo continuidad con datos locales ya guardados.
+
+## Decisiones cerradas
+1. **Contrato interno obligatorio**: toda fuente de personajes se normaliza a `FranchiseCatalog` antes de llegar a UI.
+2. **Identidad canonica**: un personaje se identifica por `character_key` (global) y siempre declara `franchise_id`; `movie_id` es obligatorio para desambiguacion visual, no para identidad.
+3. **Regla anti-duplicado principal**: el roster no permite repetir `character_key`.
+4. **Regla anti-duplicado de ingestion**: si el catalogo trae entradas repetidas con mismo `character_key`, se conserva la primera y se registran colisiones en diagnostico.
+5. **Ambiguedad visible**: si dos personajes comparten `display_name`, la UI muestra etiqueta extendida `display_name · movie_title`.
+6. **Persistencia sin ruptura**: `roster_character_ids` en `localStorage` se mantiene como `string[]`; no cambia key/version de snapshots existentes.
+7. **Compatibilidad legacy**: ids historicos no presentes en catalogo siguen cargando como seleccion valida y se renderizan con fallback (`character_id` crudo).
+8. **Estado vacio bloqueante**: si el catalogo normalizado no tiene personajes seleccionables, se deshabilita iniciar partida y se muestra estado vacio con accion de reintento.
+
+## Contrato interno `FranchiseCatalog` (v1)
+```ts
+export type FranchiseCatalog = {
+  version: 1;
+  franchises: FranchiseEntry[];
+  characters: FranchiseCharacter[];
+};
+
+export type FranchiseEntry = {
+  franchise_id: string;
+  franchise_name: string;
+};
+
+export type FranchiseCharacter = {
+  character_key: string;      // identidad canonica global, usado en roster_character_ids
+  display_name: string;       // nombre principal visible
+  franchise_id: string;       // referencia a FranchiseEntry
+  movie_id: string;           // obligatorio para desambiguacion
+  movie_title: string;        // obligatorio para etiqueta UX
+  aliases?: string[];         // opcional para busqueda
+};
+```
+
+Reglas de validez del contrato:
+- `version` debe ser `1`.
+- `franchise_id` debe existir en `franchises`.
+- `character_key` unico global en `characters`.
+- `display_name`, `movie_id`, `movie_title` no vacios.
+
+## Alcance
+- Nuevo modulo de dominio liviano para contrato/normalizacion de `FranchiseCatalog`.
+- Integracion en setup frontend para renderizar opciones de personaje desde catalogo normalizado.
+- Aplicacion de reglas anti-duplicado en seleccion y validacion local.
+- UX de estado vacio cuando no hay personajes disponibles.
+- Compatibilidad con `localStorage` existente en carga/edicion de setups.
+- Pruebas unitarias y de contratos minimas para cubrir rutas criticas.
+
+## Fuera de alcance
+- Cambios de contratos API de backend (`/api/matches`).
+- Migracion masiva de snapshots viejos a nuevo formato persistido.
+- Buscador avanzado/filtros complejos por franquicia fuera de la vista actual.
+- Resolucion semantica de variantes de un mismo personaje (skins, edades, timelines).
+
+## Diseno propuesto
+
+### 1) Dominio liviano
+- Crear `lib/domain/franchise-catalog.ts` con:
+  - Tipos `FranchiseCatalog`, `FranchiseEntry`, `FranchiseCharacter`.
+  - `normalizeFranchiseCatalog(input)` con salida `{ catalog, diagnostics }`.
+  - `buildCharacterLabel(character, hasNameCollision)` para resolver ambiguedad visual.
+- Crear schema zod en `lib/domain/schemas.ts` para validar contrato v1.
+
+### 2) Reglas anti-duplicado
+- En normalizacion:
+  - Deduplicar `characters` por `character_key`.
+  - Reportar `duplicate_character_key_count` en `diagnostics`.
+- En setup:
+  - `toggleCharacter` no agrega ids repetidos.
+  - `getSetupValidation` agrega issue si detecta duplicados en `roster_character_ids`.
+  - Mensaje de issue obligatorio: `No puedes repetir personajes en el roster.`
+
+### 3) UX estado vacio
+Condicion de activacion:
+- `catalog.characters.length === 0` luego de normalizar.
+
+Comportamiento:
+- Mostrar bloque vacio en area de roster con texto: `No hay personajes disponibles en el catalogo.`
+- Mostrar accion `Reintentar carga`.
+- Deshabilitar `Iniciar simulacion`.
+- Mantener accesibles controles no destructivos (`Volver al Lobby`, `Nuevo setup`).
+
+### 4) Compatibilidad `localStorage`
+- `LOCAL_MATCHES_STORAGE_KEY` y `LOCAL_MATCHES_SNAPSHOT_VERSION` permanecen sin cambios.
+- `roster_character_ids` sigue siendo `string[]` con ids canonicos o legacy.
+- `characterName()` retorna:
+  1. `display_name` desde catalogo si existe id.
+  2. `character_id` crudo como fallback legacy.
+- Carga de matches previos no debe fallar por ids inexistentes en catalogo actual.
+
+## Matriz minima de tests
+1. **Contrato dominio** (`tests/domain-contracts.test.ts` o nuevo `tests/franchise-catalog.test.ts`):
+- Acepta catalogo v1 valido.
+- Rechaza `character_key` duplicado.
+- Rechaza personaje con `franchise_id` inexistente.
+
+2. **Normalizacion anti-duplicado** (`tests/franchise-catalog.test.ts`):
+- Deduplica entradas repetidas por `character_key` conservando primera ocurrencia.
+- Emite diagnostico de colisiones.
+
+3. **Validacion setup** (`tests/local-matches.test.ts`):
+- Falla cuando `roster_character_ids` contiene ids repetidos.
+- Mantiene reglas existentes de min/max roster.
+
+4. **Compatibilidad legacy localStorage** (`tests/local-matches.test.ts` o `tests/match-ux.test.ts`):
+- Parsea snapshot v1 con ids antiguos no presentes en catalogo.
+- Render/fallback de nombre usa id crudo sin romper flujo.
+
+5. **UX estado vacio** (`tests/match-ux.test.ts` o test de helper extraido):
+- Cuando catalogo esta vacio, `canStart` es `false` y mensaje vacio coincide con spec.
+
+## Criterios de aceptacion verificables
+1. Existe contrato `FranchiseCatalog` v1 tipado y validado por schema.
+2. El roster no permite personajes duplicados por `character_key`.
+3. Personajes con mismo `display_name` se muestran desambiguados con `movie_title`.
+4. Con catalogo vacio, UI bloquea inicio y muestra estado vacio con reintento.
+5. Snapshots existentes en `localStorage` siguen cargando sin romper por ids legacy.
+6. La suite minima de pruebas de esta spec queda en verde.
+
+## Evidencia minima esperada en PR
+- Diff en `lib/domain/*` con contrato + normalizacion + schema.
+- Diff en `app/matches/new/page.tsx` aplicando catalogo, anti-duplicado y estado vacio.
+- Tests nuevos/ajustados en `tests/` cubriendo matriz minima.
+- Resultado de `pnpm run test:unit` incluido en descripcion del PR.
+
+## Checklist de handoff a implementacion
+- [ ] Definir tipos `FranchiseCatalog` v1 en dominio.
+- [ ] Agregar validacion zod del catalogo y referencias internas.
+- [ ] Implementar normalizacion con diagnostico de duplicados.
+- [ ] Integrar catalogo en setup frontend y desambiguacion visual pelicula/personaje.
+- [ ] Bloquear inicio y mostrar UX de estado vacio cuando no haya personajes.
+- [ ] Forzar regla anti-duplicado en seleccion + validacion de setup.
+- [ ] Mantener compatibilidad de snapshots `localStorage` sin bump de version.
+- [ ] Cubrir matriz minima de tests definida en esta spec.
+- [ ] Ejecutar `pnpm run test:unit`.

--- a/tests/domain-contracts.test.ts
+++ b/tests/domain-contracts.test.ts
@@ -156,6 +156,25 @@ describe('create_match request contract', () => {
 
     expect(createMatchRequestSchema.safeParse(payload).success).toBe(false);
   });
+
+  it('rejects payload with duplicated roster_character_ids', () => {
+    const payload = {
+      roster_character_ids: [
+        'char-1',
+        'char-2',
+        'char-3',
+        'char-4',
+        'char-5',
+        'char-6',
+        'char-7',
+        'char-8',
+        'char-9',
+        'char-1'
+      ]
+    };
+
+    expect(createMatchRequestSchema.safeParse(payload).success).toBe(false);
+  });
 });
 
 describe('match lifecycle response contracts', () => {

--- a/tests/franchise-catalog.test.ts
+++ b/tests/franchise-catalog.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it } from 'vitest';
+import { franchiseCatalogSchema } from '@/lib/domain/schemas';
+import {
+  buildCharacterLabel,
+  buildRosterFromMovieSelection,
+  DEFAULT_FRANCHISE_CATALOG_SOURCE,
+  listFranchiseMovies,
+  normalizeFranchiseCatalog
+} from '@/lib/domain/franchise-catalog';
+
+describe('franchise catalog schema', () => {
+  it('accepts valid v1 catalog', () => {
+    const payload = {
+      version: 1,
+      franchises: [{ franchise_id: 'f-1', franchise_name: 'Franchise 1' }],
+      characters: [
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        }
+      ]
+    };
+
+    expect(franchiseCatalogSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('rejects duplicated character_key', () => {
+    const payload = {
+      version: 1,
+      franchises: [{ franchise_id: 'f-1', franchise_name: 'Franchise 1' }],
+      characters: [
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        },
+        {
+          character_key: 'char-1',
+          display_name: 'Alex v2',
+          franchise_id: 'f-1',
+          movie_id: 'm-2',
+          movie_title: 'Movie 2'
+        }
+      ]
+    };
+
+    expect(franchiseCatalogSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects character with missing franchise reference', () => {
+    const payload = {
+      version: 1,
+      franchises: [{ franchise_id: 'f-1', franchise_name: 'Franchise 1' }],
+      characters: [
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'unknown',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        }
+      ]
+    };
+
+    expect(franchiseCatalogSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe('franchise catalog normalization', () => {
+  it('deduplicates repeated character_key preserving first entry', () => {
+    const input = {
+      version: 1,
+      franchises: [{ franchise_id: 'f-1', franchise_name: 'Franchise 1' }],
+      characters: [
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        },
+        {
+          character_key: 'char-1',
+          display_name: 'Alex Duplicate',
+          franchise_id: 'f-1',
+          movie_id: 'm-2',
+          movie_title: 'Movie 2'
+        },
+        {
+          character_key: 'char-2',
+          display_name: 'Sam',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        }
+      ]
+    };
+
+    const result = normalizeFranchiseCatalog(input);
+    expect(result.catalog.characters).toHaveLength(2);
+    expect(result.catalog.characters[0].display_name).toBe('Alex');
+    expect(result.diagnostics.duplicate_character_key_count).toBe(1);
+    expect(result.diagnostics.invalid_version_count).toBe(0);
+  });
+
+  it('returns empty catalog when payload is invalid', () => {
+    const result = normalizeFranchiseCatalog({ version: 1, franchises: 'bad', characters: [] });
+
+    expect(result.catalog.characters).toEqual([]);
+    expect(result.catalog.franchises).toEqual([]);
+    expect(result.diagnostics.invalid_version_count).toBe(0);
+  });
+
+  it('counts dropped_character_count using real discarded characters', () => {
+    const input = {
+      version: 1,
+      franchises: [{ franchise_id: 'f-1', franchise_name: 'Franchise 1' }],
+      characters: [
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        },
+        {
+          character_key: 'char-1',
+          display_name: 'Alex Duplicate',
+          franchise_id: 'f-1',
+          movie_id: 'm-2',
+          movie_title: 'Movie 2'
+        },
+        {
+          character_key: 'char-2',
+          display_name: 'Sam',
+          franchise_id: 'unknown',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        },
+        {
+          display_name: 'Missing key',
+          franchise_id: 'f-1',
+          movie_id: 'm-3',
+          movie_title: 'Movie 3'
+        }
+      ]
+    };
+
+    const result = normalizeFranchiseCatalog(input);
+
+    expect(result.catalog.characters).toHaveLength(1);
+    expect(result.diagnostics.dropped_character_count).toBe(3);
+    expect(result.diagnostics.duplicate_character_key_count).toBe(1);
+    expect(result.diagnostics.invalid_entry_count).toBe(2);
+    expect(result.diagnostics.invalid_version_count).toBe(0);
+  });
+
+  it.each([
+    { name: 'invalid numeric version', version: 2 },
+    { name: 'non-numeric version', version: 'v2' }
+  ])('reports invalid_version_count for $name', ({ version }) => {
+    const input = {
+      version,
+      franchises: [{ franchise_id: 'f-1', franchise_name: 'Franchise 1' }],
+      characters: [
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        }
+      ]
+    };
+
+    const result = normalizeFranchiseCatalog(input);
+
+    expect(result.catalog.version).toBe(1);
+    expect(result.catalog.characters).toHaveLength(1);
+    expect(result.catalog.franchises).toHaveLength(1);
+    expect(result.diagnostics.invalid_entry_count).toBe(0);
+    expect(result.diagnostics.invalid_version_count).toBe(1);
+  });
+
+  it('returns empty catalog diagnostics for non-object payload', () => {
+    const result = normalizeFranchiseCatalog(null);
+
+    expect(result.catalog).toEqual({
+      version: 1,
+      franchises: [],
+      characters: []
+    });
+    expect(result.diagnostics).toEqual({
+      duplicate_character_key_count: 0,
+      dropped_character_count: 0,
+      invalid_entry_count: 1,
+      invalid_version_count: 0
+    });
+  });
+
+  it('sanitizes invalid franchise entries and non-array characters payloads', () => {
+    const result = normalizeFranchiseCatalog({
+      version: 1,
+      franchises: [
+        null,
+        { franchise_id: '', franchise_name: 'Invalid blank id' },
+        { franchise_id: 'f-1', franchise_name: 'Franchise 1' },
+        { franchise_id: 'f-1', franchise_name: 'Duplicate franchise' },
+        { franchise_id: 'f-2', franchise_name: 42 }
+      ],
+      characters: 'bad'
+    });
+
+    expect(result.catalog.franchises).toEqual([
+      { franchise_id: 'f-1', franchise_name: 'Franchise 1' }
+    ]);
+    expect(result.catalog.characters).toEqual([]);
+    expect(result.diagnostics.dropped_character_count).toBe(0);
+    expect(result.diagnostics.invalid_entry_count).toBe(0);
+  });
+
+  it('counts non-object and malformed characters while sanitizing aliases', () => {
+    const result = normalizeFranchiseCatalog({
+      version: 1,
+      franchises: [{ franchise_id: 'f-1', franchise_name: 'Franchise 1' }],
+      characters: [
+        123,
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1',
+          aliases: ['Alias', '', 99]
+        },
+        {
+          character_key: 'char-2',
+          display_name: 999,
+          franchise_id: 'f-1',
+          movie_id: 'm-2',
+          movie_title: 'Movie 2'
+        }
+      ]
+    });
+
+    expect(result.catalog.characters).toEqual([
+      {
+        character_key: 'char-1',
+        display_name: 'Alex',
+        franchise_id: 'f-1',
+        movie_id: 'm-1',
+        movie_title: 'Movie 1',
+        aliases: ['Alias']
+      }
+    ]);
+    expect(result.diagnostics.invalid_entry_count).toBe(2);
+    expect(result.diagnostics.dropped_character_count).toBe(2);
+  });
+});
+
+describe('buildCharacterLabel', () => {
+  it('returns plain display name when there is no collision', () => {
+    expect(
+      buildCharacterLabel(
+        {
+          display_name: 'Alex',
+          movie_title: 'Movie 1'
+        },
+        false
+      )
+    ).toBe('Alex');
+  });
+
+  it('appends movie title when display name collides', () => {
+    expect(
+      buildCharacterLabel(
+        {
+          display_name: 'Alex',
+          movie_title: 'Movie 1'
+        },
+        true
+      )
+    ).toBe('Alex · Movie 1');
+  });
+});
+
+describe('default catalog and selection helpers', () => {
+  it('loads hardcoded catalog with popular franchises and movies', () => {
+    const normalized = normalizeFranchiseCatalog(DEFAULT_FRANCHISE_CATALOG_SOURCE);
+
+    expect(normalized.catalog.franchises.length).toBeGreaterThanOrEqual(3);
+    expect(normalized.catalog.characters.length).toBeGreaterThanOrEqual(20);
+    expect(normalized.catalog.franchises.some((entry) => entry.franchise_name === 'Star Wars')).toBe(
+      true
+    );
+  });
+
+  it('lists only movies for selected franchise', () => {
+    const normalized = normalizeFranchiseCatalog(DEFAULT_FRANCHISE_CATALOG_SOURCE);
+    const franchiseId = normalized.catalog.franchises[0]?.franchise_id ?? '';
+    const movies = listFranchiseMovies(normalized.catalog, franchiseId);
+
+    expect(movies.length).toBeGreaterThanOrEqual(2);
+    expect(movies.every((movie) => movie.franchise_id === franchiseId)).toBe(true);
+  });
+
+  it('returns empty movie list for unknown franchise', () => {
+    const normalized = normalizeFranchiseCatalog(DEFAULT_FRANCHISE_CATALOG_SOURCE);
+
+    expect(listFranchiseMovies(normalized.catalog, 'missing')).toEqual([]);
+  });
+
+  it('generates roster only from selected movies without duplicates', () => {
+    const catalog = {
+      version: 1 as const,
+      franchises: [{ franchise_id: 'f-1', franchise_name: 'Franchise 1' }],
+      characters: [
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        },
+        {
+          character_key: 'char-1',
+          display_name: 'Alex Duplicate',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        },
+        {
+          character_key: 'char-2',
+          display_name: 'Sam',
+          franchise_id: 'f-1',
+          movie_id: 'm-2',
+          movie_title: 'Movie 2'
+        },
+        {
+          character_key: 'char-3',
+          display_name: 'Taylor',
+          franchise_id: 'f-1',
+          movie_id: 'm-3',
+          movie_title: 'Movie 3'
+        }
+      ]
+    };
+
+    const normalized = normalizeFranchiseCatalog(catalog).catalog;
+    const roster = buildRosterFromMovieSelection(normalized, 'f-1', ['m-1', 'm-2']);
+
+    expect(roster).toEqual(['char-1', 'char-2']);
+    expect(new Set(roster).size).toBe(roster.length);
+  });
+
+  it('returns empty roster when franchise is null or movie filter is empty', () => {
+    const normalized = normalizeFranchiseCatalog(DEFAULT_FRANCHISE_CATALOG_SOURCE).catalog;
+
+    expect(buildRosterFromMovieSelection(normalized, null, ['sw-anh'])).toEqual([]);
+    expect(buildRosterFromMovieSelection(normalized, 'sw', [])).toEqual([]);
+  });
+
+  it('skips characters from other franchises and repeated keys while building roster', () => {
+    const catalog = {
+      version: 1 as const,
+      franchises: [
+        { franchise_id: 'f-1', franchise_name: 'Franchise 1' },
+        { franchise_id: 'f-2', franchise_name: 'Franchise 2' }
+      ],
+      characters: [
+        {
+          character_key: 'char-1',
+          display_name: 'Alex',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        },
+        {
+          character_key: 'char-1',
+          display_name: 'Alex Duplicate',
+          franchise_id: 'f-1',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        },
+        {
+          character_key: 'char-2',
+          display_name: 'Casey',
+          franchise_id: 'f-2',
+          movie_id: 'm-1',
+          movie_title: 'Movie 1'
+        }
+      ]
+    };
+
+    expect(buildRosterFromMovieSelection(catalog, 'f-1', ['m-1'])).toEqual(['char-1']);
+  });
+});

--- a/tests/local-matches.test.ts
+++ b/tests/local-matches.test.ts
@@ -52,6 +52,15 @@ describe('getSetupValidation', () => {
       issues: ['No puedes seleccionar mas de 48 personajes.']
     });
   });
+
+  it('rejects duplicated characters in roster', () => {
+    const roster = ['char-1', 'char-2', 'char-2', 'char-3', 'char-4', 'char-5', 'char-6', 'char-7', 'char-8', 'char-9'];
+
+    expect(getSetupValidation(roster)).toEqual({
+      is_valid: false,
+      issues: ['No puedes repetir personajes en el roster.']
+    });
+  });
 });
 
 describe('parseLocalMatches', () => {


### PR DESCRIPTION
## Scope
- Selección de roster por franquicia y películas populares en setup.
- Roster generado solo desde películas seleccionadas con deduplicación.
- Hardening de contrato API para rechazar `roster_character_ids` duplicados.
- Ajustes de compatibilidad legacy y diagnósticos de catálogo.

## Validación
- pnpm run lint ✅
- pnpm run test:unit ✅
- pnpm run test:coverage ✅
- pnpm run validate ✅

Closes #78
