### PR TITLE
build: include e2e in validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,13 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
       - name: Lint
         run: pnpm run lint
       - name: Test
         run: pnpm run test:unit
       - name: Coverage
         run: pnpm run test:coverage
+      - name: E2E
+        run: pnpm run test:e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@
 - `pnpm run build`: production build.
 - `pnpm run start`: run built app.
 - `pnpm run lint`: run Next.js linting.
+- `pnpm run test:e2e`: run Playwright end-to-end tests.
 - `pnpm run test:unit`: run unit tests.
 - `pnpm run test:coverage`: run tests with coverage report.
-- `pnpm run validate`: lint + unit + coverage gate.
+- `pnpm run validate`: lint + unit + coverage + e2e gate.
 
 ## Coding Style & Naming Conventions
 
@@ -28,6 +29,7 @@
 ## Testing Guidelines
 
 - Test framework: Vitest (`tests/**/*.test.ts`).
+- E2E framework: Playwright (`tests/e2e/**/*.spec.ts`).
 - Coverage uses V8 provider with thresholds at 90% (lines/functions/branches/statements).
 - Add/update tests in `tests/` alongside behavioral changes in `app/` or `lib/`.
 - Run `pnpm run validate` before opening a PR.
@@ -38,7 +40,7 @@
 - Group related changes; avoid bundling unrelated refactors.
 - PR should include:
   - Scope and user-visible behavior changes.
-  - Commands executed (`pnpm run lint`, `pnpm run test:unit`, `pnpm run test:coverage`).
+  - Commands executed (`pnpm run lint`, `pnpm run test:unit`, `pnpm run test:coverage`, `pnpm run test:e2e`).
   - Any spec/plan updates under `specs/` when applicable.
 
 ## Security & Configuration Tips

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Permite crear partidas, avanzar turnos con tension dinamica y reanudar sesiones 
 - Framework: Next.js App Router
 - Lenguaje: TypeScript estricto
 - Validacion de contratos: Zod
-- Testing: Vitest + cobertura V8 (threshold `90%`)
+- Testing: Vitest + cobertura V8 (threshold `90%`) + Playwright E2E
 - Estado de juego server-side: memoria en proceso (`Map` en `lib/matches/lifecycle.ts`)
 
 ## Inicio rapido
@@ -41,9 +41,10 @@ Aplicacion local: [http://localhost:3000](http://localhost:3000)
 | `pnpm run build` | Build de produccion |
 | `pnpm run start` | Ejecuta build generado |
 | `pnpm run lint` | Lint de Next.js |
+| `pnpm run test:e2e` | Tests E2E con Playwright |
 | `pnpm run test:unit` | Tests unitarios |
 | `pnpm run test:coverage` | Tests con cobertura |
-| `pnpm run validate` | Gate completo (`lint + unit + coverage`) |
+| `pnpm run validate` | Gate completo (`lint + unit + coverage + e2e`) |
 
 ## Observabilidad
 

--- a/docs/technical-guidelines.md
+++ b/docs/technical-guidelines.md
@@ -8,7 +8,7 @@ La implementación de eventos aleatorios cinematográficos debe respetar el mode
 - Dominio: `lib/domain/types.ts`, `lib/domain/schemas.ts`.
 - Simulación: `lib/simulation-state.ts`, `lib/matches/lifecycle.ts`.
 - Validación: Zod.
-- Testing: Vitest + coverage V8.
+- Testing: Vitest + coverage V8 + Playwright E2E.
 
 ## 3. Architecture Patterns
 - Arquitectura modular por capas: API -> lifecycle/application -> simulation/domain.
@@ -58,6 +58,7 @@ La implementación de eventos aleatorios cinematográficos debe respetar el mode
   - Condiciones de activación Cornucopia refill.
   - Evento escape con muerte automática.
 - Contract tests para garantizar que endpoint no rompe schema.
+- E2E con Playwright para validar flujos criticos de usuario.
 - Cobertura objetivo >=90%.
 
 ## 12. Code Quality & Standards
@@ -67,7 +68,7 @@ La implementación de eventos aleatorios cinematográficos debe respetar el mode
 
 ## 13. Deployment & DevOps
 - Sin cambios de infraestructura.
-- Feature se despliega con pipeline actual (`pnpm run validate` como gate).
+- Feature se despliega con pipeline actual (`pnpm run validate` como gate, incluyendo E2E).
 
 ## 14. Monitoring, Logging & Observability
 - Emitir logs estructurados existentes (`match.turn.event`) con template/evento seleccionado.
@@ -87,7 +88,7 @@ La implementación de eventos aleatorios cinematográficos debe respetar el mode
 
 ## 17. Development Workflow
 - Commits convencionales.
-- Ejecutar `pnpm run lint`, `pnpm run test:unit`, `pnpm run test:coverage`.
+- Ejecutar `pnpm run lint`, `pnpm run test:unit`, `pnpm run test:coverage`, `pnpm run test:e2e`.
 - Mantener cambios sincronizados entre contratos y pruebas.
 
 ## 18. Known Constraints & Trade-offs

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "playwright test",
     "test:unit": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "validate": "pnpm run lint && pnpm run test:unit && pnpm run test:coverage",
+    "validate": "pnpm run lint && pnpm run test:unit && pnpm run test:coverage && pnpm run test:e2e",
     "prepare": "husky"
   },
   "dependencies": {

--- a/specs/plans/release-gate-v1.md
+++ b/specs/plans/release-gate-v1.md
@@ -6,7 +6,7 @@
 
 ## Checklist de salida
 
-- [x] Validacion final de calidad: `npm run validate` (lint + unit + coverage >= 90%).
+- [x] Validacion final de calidad: `pnpm run validate` (lint + unit + coverage >= 90% + e2e).
 - [x] Continuidad stateless por snapshot local valida en flujo `resume`.
 - [x] Snapshot incompatible rechazado de forma explicita con `partida no recuperable`.
 - [x] Sin persistencia de estado en filesystem de servidor (arquitectura stateless por request).

--- a/tests/e2e/happy-paths.spec.ts
+++ b/tests/e2e/happy-paths.spec.ts
@@ -98,6 +98,8 @@ test('HP-03 reanuda una partida guardada desde historial', async ({ page }) => {
   await startSimulation(page, 'arena-hp03', '4x');
   await page.getByRole('button', { name: 'Paso' }).click();
   await expect(page.getByTestId('kpi-turn')).toContainText('1');
+  await page.getByRole('button', { name: 'Pausa' }).click();
+  await expect(page.getByTestId('kpi-speed')).toContainText('Pausa');
 
   const expectedTurn = await getRuntimeTurn(page);
 


### PR DESCRIPTION
## Summary
- include Playwright E2E in `pnpm run validate`
- align CI to install Chromium and run the E2E job
- update repo docs and stabilize the flaky HP-03 E2E resume flow

## Validation
- pnpm run validate
- pnpm run build