### PR TITLE
feat(ui): migrate session studio header to shadcn-style primitives

### DIFF
--- a/app/components/ui/badge.tsx
+++ b/app/components/ui/badge.tsx
@@ -1,0 +1,25 @@
+import type { HTMLAttributes } from 'react';
+import styles from './primitives.module.css';
+import { cn } from './utils';
+
+type BadgeVariant = 'secondary' | 'destructive' | 'warning' | 'success';
+
+type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
+  variant?: BadgeVariant;
+};
+
+export function Badge({ className, variant = 'secondary', ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        styles.badge,
+        variant === 'secondary' && styles.badgeSecondary,
+        variant === 'destructive' && styles.badgeDestructive,
+        variant === 'warning' && styles.badgeWarning,
+        variant === 'success' && styles.badgeSuccess,
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -1,0 +1,27 @@
+import type { ButtonHTMLAttributes } from 'react';
+import styles from './primitives.module.css';
+import { cn } from './utils';
+
+type ButtonVariant = 'default' | 'outline' | 'ghost';
+type ButtonSize = 'sm' | 'md';
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+};
+
+export function Button({ className, variant = 'default', size = 'md', ...props }: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        styles.button,
+        variant === 'default' && styles.buttonDefault,
+        variant === 'outline' && styles.buttonOutline,
+        variant === 'ghost' && styles.buttonGhost,
+        size === 'sm' ? styles.buttonSm : styles.buttonMd,
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/app/components/ui/card.tsx
+++ b/app/components/ui/card.tsx
@@ -1,0 +1,11 @@
+import type { HTMLAttributes } from 'react';
+import styles from './primitives.module.css';
+import { cn } from './utils';
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLElement>) {
+  return <section className={cn(styles.card, className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn(styles.cardContent, className)} {...props} />;
+}

--- a/app/components/ui/primitives.module.css
+++ b/app/components/ui/primitives.module.css
@@ -1,0 +1,138 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.6rem 0.9rem;
+  cursor: pointer;
+  transition: all 160ms ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.buttonDefault {
+  background: linear-gradient(135deg, var(--cta-a), var(--cta-b));
+  color: var(--cta-ink);
+}
+
+.buttonDefault:hover {
+  filter: brightness(1.05);
+}
+
+.buttonOutline {
+  background: var(--panel);
+  color: var(--ink);
+  border-color: color-mix(in oklab, var(--border), var(--ink) 16%);
+}
+
+.buttonGhost {
+  background: transparent;
+  color: var(--ink);
+}
+
+.buttonSm {
+  padding: 0.4rem 0.65rem;
+  font-size: 0.82rem;
+}
+
+.buttonMd {
+  padding: 0.6rem 0.9rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.badgeSecondary {
+  color: var(--muted);
+  background: color-mix(in oklab, var(--panel), var(--ink) 2%);
+  border-color: var(--border);
+}
+
+.badgeDestructive {
+  color: #fff;
+  background: color-mix(in oklab, var(--danger), #000 6%);
+}
+
+.badgeWarning {
+  color: var(--ink);
+  background: color-mix(in oklab, #f2ca7f, #fff 25%);
+}
+
+.badgeSuccess {
+  color: var(--ink);
+  background: color-mix(in oklab, #97d2b2, #fff 20%);
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--panel);
+  box-shadow: 0 12px 34px rgba(18, 32, 40, 0.08);
+}
+
+.cardContent {
+  padding: 1rem;
+}
+
+.progress {
+  width: 100%;
+  height: 0.72rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--border), #fff 22%);
+  background: color-mix(in oklab, var(--panel), var(--ink) 5%);
+  overflow: hidden;
+}
+
+.progressIndicator {
+  height: 100%;
+  width: 100%;
+  transform-origin: left;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  transition: transform 220ms ease;
+}
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 2.7rem;
+  height: 1.55rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--border), var(--ink) 14%);
+  background: color-mix(in oklab, var(--panel), var(--ink) 7%);
+  cursor: pointer;
+  transition: all 180ms ease;
+}
+
+.switchChecked {
+  background: color-mix(in oklab, var(--accent), #fff 20%);
+}
+
+.switchThumb {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-left: 0.2rem;
+  border-radius: 999px;
+  background: var(--panel);
+  border: 1px solid color-mix(in oklab, var(--border), var(--ink) 8%);
+  transition: transform 180ms ease;
+}
+
+.switchChecked .switchThumb {
+  transform: translateX(1.12rem);
+}

--- a/app/components/ui/progress.tsx
+++ b/app/components/ui/progress.tsx
@@ -1,0 +1,21 @@
+import type { HTMLAttributes } from 'react';
+import styles from './primitives.module.css';
+import { cn } from './utils';
+
+type ProgressProps = HTMLAttributes<HTMLDivElement> & {
+  value: number;
+};
+
+export function Progress({ value, className, ...props }: ProgressProps) {
+  const boundedValue = Math.min(100, Math.max(0, value));
+
+  return (
+    <div className={cn(styles.progress, className)} {...props}>
+      <div
+        className={styles.progressIndicator}
+        style={{ transform: `scaleX(${boundedValue / 100})` }}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}

--- a/app/components/ui/switch.tsx
+++ b/app/components/ui/switch.tsx
@@ -1,0 +1,23 @@
+import type { ButtonHTMLAttributes } from 'react';
+import styles from './primitives.module.css';
+import { cn } from './utils';
+
+type SwitchProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> & {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+};
+
+export function Switch({ checked, onCheckedChange, className, ...props }: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      className={cn(styles.switch, checked && styles.switchChecked, className)}
+      onClick={() => onCheckedChange(!checked)}
+      {...props}
+    >
+      <span className={styles.switchThumb} />
+    </button>
+  );
+}

--- a/app/components/ui/utils.ts
+++ b/app/components/ui/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ');
+}

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -31,6 +31,10 @@ import { recordCounterMetric, recordThresholdAlert } from '@/lib/observability';
 import { useRosterSelection } from './use-roster-selection';
 import { CatalogSelection } from './components/catalog-selection';
 import { RosterPreview } from './components/roster-preview';
+import { Badge } from '@/app/components/ui/badge';
+import { Card, CardContent } from '@/app/components/ui/card';
+import { Progress } from '@/app/components/ui/progress';
+import { Switch } from '@/app/components/ui/switch';
 import type {
   AdvanceTurnResponse,
   CreateMatchResponse,
@@ -184,6 +188,20 @@ function sessionSizeTone(bytes: number): 'ok' | 'high' | 'critical' {
     return 'high';
   }
   return 'ok';
+}
+
+function sessionToneBadgeVariant(
+  tone: ReturnType<typeof sessionSizeTone>
+): 'success' | 'warning' | 'destructive' {
+  if (tone === 'critical') {
+    return 'destructive';
+  }
+
+  if (tone === 'high') {
+    return 'warning';
+  }
+
+  return 'success';
 }
 
 function countAlive(participants: ParticipantState[]): number {
@@ -1148,7 +1166,8 @@ export function MatchStudioPage({
   return (
     <main className={styles.page} aria-busy={isTransitioning}>
       <div className={styles.shell}>
-        <header className={styles.hero}>
+        <Card className={styles.hero}>
+          <CardContent>
           <div className={styles.heroTop}>
             <h1 className={styles.title}>Hunger Games Simulator</h1>
             <div className={styles.inlineControls}>
@@ -1165,28 +1184,16 @@ export function MatchStudioPage({
             <span>
               Sesion actual: <strong>{currentSessionSizeLabel}</strong>
             </span>
-            <span
-              className={`${styles.sessionTone} ${
-                currentSessionSizeTone === 'critical'
-                  ? styles.sessionToneCritical
-                  : currentSessionSizeTone === 'high'
-                    ? styles.sessionToneHigh
-                    : styles.sessionToneOk
-              }`}
-            >
+            <Badge variant={sessionToneBadgeVariant(currentSessionSizeTone)}>
               {currentSessionSizeTone === 'critical'
                 ? 'Critico'
                 : currentSessionSizeTone === 'high'
                   ? 'Alto'
                   : 'OK'}
-            </span>
+            </Badge>
           </div>
           <label className={styles.autosaveToggle}>
-            <input
-              type="checkbox"
-              checked={autosaveEnabled}
-              onChange={(event) => onToggleAutosave(event.target.checked)}
-            />
+            <Switch checked={autosaveEnabled} onCheckedChange={onToggleAutosave} />
             Guardar local
           </label>
           {!autosaveEnabled ? (
@@ -1216,21 +1223,18 @@ export function MatchStudioPage({
 
           <div className={styles.tension} aria-label="barra de tension">
             <strong>Tension {Math.round(tensionValue)}%</strong>
-            <div
+            <Progress
               className={styles.tensionTrack}
               role="progressbar"
               aria-label="Nivel de tension"
               aria-valuemin={0}
               aria-valuemax={100}
               aria-valuenow={Math.round(Math.min(100, tensionValue))}
-            >
-              <div
-                className={styles.tensionBar}
-                style={{ transform: `scaleX(${Math.min(100, tensionValue) / 100})` }}
-              />
-            </div>
+              value={tensionValue}
+            />
           </div>
-        </header>
+          </CardContent>
+        </Card>
 
         <div className={styles.columns}>
           {!runtime && !isSessionView ? (


### PR DESCRIPTION
### Motivation
- Replace ad-hoc header UI with a small set of shadcn-style primitives to improve visual consistency and enable reuse across the simulator pages.
- Move session-specific presentation concerns (tone badge, autosave toggle, tension meter, hero container) into small, testable components to simplify the `MatchStudioPage` layout.

### Description
- Added a local primitives set under `app/components/ui` including `Card`/`CardContent`, `Badge`, `Progress`, `Switch`, a `cn` helper, and `primitives.module.css` for shared styles.
- Migrated the header/hero block in `app/new/page.tsx` to use `Card` + `CardContent`, replaced the session tone span with `Badge`, replaced the autosave checkbox with `Switch`, and replaced the tension bar with `Progress` and a semantic `sessionToneBadgeVariant` mapping.
- Kept all existing labels, accessibility attributes and runtime behavior unchanged while switching to the new components to preserve current UX.

### Testing
- Ran `pnpm run lint` and it completed with no ESLint errors.
- Ran `pnpm run test:unit` and the full unit suite passed (`171 tests` across `18` files succeeded).
- Ran `pnpm run test:coverage` and coverage ran successfully (project coverage ~91.65%).
- Attempted `pnpm run test:e2e` which failed in this environment because the Playwright Chromium headless shell requires an OS-level library (`libatk-1.0.so.0`) that is missing; `pnpm exec playwright install chromium` succeeded in downloading browser binaries but the system library issue prevents e2e browser launch in the container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6d570158c83278bbb7fac410ea21f)