### PR TITLE
[codex] add product analytics observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@
 
 - Follow Conventional Commits with action-oriented subjects.
 - Group related changes; avoid bundling unrelated refactors.
+- Never commit, push, create a PR, or update an existing PR without explicit user approval immediately before publishing.
+- After making changes, leave them local so the user can review them before approving publication.
 - PR should include:
   - Scope and user-visible behavior changes.
   - Commands executed (`pnpm run lint`, `pnpm run test:unit`, `pnpm run test:coverage`, `pnpm run test:e2e`).

--- a/README.md
+++ b/README.md
@@ -48,10 +48,24 @@ Local app: [http://localhost:3000](http://localhost:3000)
 
 ## Observability
 
-- Vercel Analytics enabled in `app/layout.tsx` with `@vercel/analytics`.
-- Google Analytics 4 enabled in `app/layout.tsx` with `NEXT_PUBLIC_GA_MEASUREMENT_ID`.
-- PostHog enabled in `app/layout.tsx` with `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST`.
-- Cloudflare Web Analytics enabled in `app/layout.tsx` using the official beacon.
+Each tool answers a different question:
+
+| Tool | Purpose | Use it to answer |
+| --- | --- | --- |
+| PostHog | Product analytics source of truth | Do users start and finish matches? Which features and flows work? |
+| Google Analytics 4 | Acquisition and marketing analytics | Where does traffic come from? Which campaigns produce conversions? |
+| Vercel Analytics | Vercel-hosted page and frontend performance analytics | Are pages fast and did a deployment regress Web Vitals? |
+| Cloudflare Web Analytics | Privacy-oriented edge traffic baseline | How many visits and page views reach the domain? |
+
+Implementation:
+
+- Vercel Analytics is enabled in `app/layout.tsx` with `@vercel/analytics`.
+- Google Analytics 4 is enabled in `app/layout.tsx` with `NEXT_PUBLIC_GA_MEASUREMENT_ID`.
+- PostHog is enabled in `app/layout.tsx` with `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST`.
+- Cloudflare Web Analytics is enabled in `app/layout.tsx` using the official beacon.
+- Product events belong in PostHog. Send an event to GA4 only when it is also a marketing conversion.
+- Do not send roster names, seeds, snapshot contents, or other user-generated match data.
+- Totals between tools are not expected to match because collection points, consent, blockers, and bot filtering differ.
 - Required configuration:
   - `NEXT_PUBLIC_GA_MEASUREMENT_ID`
   - `NEXT_PUBLIC_POSTHOG_KEY`

--- a/app/_sessions/history-view.tsx
+++ b/app/_sessions/history-view.tsx
@@ -85,6 +85,7 @@ export function MatchArchiveTable({
           <Label className="grid gap-2 text-sm font-semibold text-foreground">
             Buscar
             <Input
+              data-analytics-control="history_search"
               placeholder="id corta o seed"
               value={searchTerm}
               onChange={(event) => onSearchTermChange(event.target.value)}
@@ -94,6 +95,7 @@ export function MatchArchiveTable({
           <Label className="grid gap-2 text-sm font-semibold text-foreground">
             Estado
             <Select
+              data-analytics-control="history_status_filter"
               value={statusFilter}
               onChange={(event) => onStatusFilterChange(event.target.value as HistoryFilter)}
             >

--- a/app/components/help-feedback-dialog.tsx
+++ b/app/components/help-feedback-dialog.tsx
@@ -200,6 +200,7 @@ export function HelpFeedbackDialog({ open, onOpenChange }: HelpFeedbackDialogPro
               Por si quieres ser contactado
             </span>
             <Input
+              data-analytics-control="feedback_email"
               type="email"
               value={email}
               onChange={(event) => setEmail(event.target.value)}

--- a/app/new/components/catalog-selection.tsx
+++ b/app/new/components/catalog-selection.tsx
@@ -74,6 +74,7 @@ export function CatalogSelection(props: CatalogSelectionProps) {
                       className="flex items-center gap-2 rounded-md bg-muted px-3 py-2"
                     >
                       <Checkbox
+                        data-analytics-control="movie_selection"
                         id={`movie-${movie.movie_id}`}
                         checked={checked}
                         onChange={() => toggleMovie(movie.movie_id)}

--- a/app/new/components/roster-preview.tsx
+++ b/app/new/components/roster-preview.tsx
@@ -51,6 +51,7 @@ export function RosterPreview(props: RosterPreviewProps) {
             className="flex w-fit items-center gap-2 rounded-md border px-3 py-2 text-sm"
           >
             <Checkbox
+              data-analytics-control="roster_select_all"
               id="roster-select-all"
               aria-label="Seleccionar todo el roster"
               checked={allSelectableCharactersSelected}
@@ -83,6 +84,7 @@ export function RosterPreview(props: RosterPreviewProps) {
                   className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-[12.5px]"
                 >
                   <Checkbox
+                    data-analytics-control="roster_character_selection"
                     id={checkboxId}
                     aria-label={`Seleccionar ${label}`}
                     checked={selectedCharacterSet.has(character.character_key)}
@@ -105,6 +107,7 @@ export function RosterPreview(props: RosterPreviewProps) {
                   className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-[12.5px] opacity-75"
                 >
                   <Checkbox
+                    data-analytics-control="roster_selected_character"
                     id={checkboxId}
                     aria-label={`Roster seleccionado ${label}`}
                     checked

--- a/app/new/match-studio-page.tsx
+++ b/app/new/match-studio-page.tsx
@@ -64,6 +64,7 @@ import { Progress } from '@/components/ui/progress';
 import { Select } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
+import { captureProductEvent } from '@/lib/product-analytics';
 import type {
   AdvanceTurnResponse,
   CreateMatchResponse,
@@ -623,6 +624,39 @@ export function MatchStudioPage({
         const nextMatches = [newSummary, ...localMatches.filter((match) => match.id !== newSummary.id)];
         persistLocalMatches(nextMatches);
       }
+      captureProductEvent('match_started', {
+        match_id: createResponse.match_id,
+        franchise:
+          franchiseOptions.find((franchise) => franchise.franchise_id === selectedFranchiseId)
+            ?.franchise_name ?? null,
+        movie_count: selectedMovieIds.length,
+        roster_size: selectedCharacters.length,
+        event_profile: eventProfile,
+        surprise_level: surpriseLevel,
+        autosave_enabled: autosaveEnabled
+      });
+      moviesForSelectedFranchise
+        .filter((movie) => selectedMovieIds.includes(movie.movie_id))
+        .forEach((movie) => {
+          captureProductEvent('match_movie_used', {
+            match_id: createResponse.match_id,
+            movie: movie.movie_title,
+            franchise:
+              franchiseOptions.find((franchise) => franchise.franchise_id === selectedFranchiseId)
+                ?.franchise_name ?? null
+          });
+        });
+      selectedCharacters.forEach((characterId) => {
+        const character = characterById.get(characterId);
+        captureProductEvent('match_character_used', {
+          match_id: createResponse.match_id,
+          character: characterName(characterId),
+          movie: character?.movie_title ?? null,
+          franchise:
+            franchiseOptions.find((franchise) => franchise.franchise_id === selectedFranchiseId)
+              ?.franchise_name ?? null
+        });
+      });
       router.replace(`/sessions/${createResponse.match_id}`, { scroll: false });
       setInfoMessage(`Simulacion iniciada (${shortId(createResponse.match_id)}).`);
     } catch (error) {
@@ -837,12 +871,25 @@ export function MatchStudioPage({
 
       if (advance.finished) {
         setPlaybackSpeed('pause');
-        const winnerName =
+        const winnerCharacterId =
           state.participants.find((participant) => participant.id === advance.winner_id)?.character_id ??
           null;
+        captureProductEvent('match_finished', {
+          match_id: runtime.match_id,
+          winner: winnerCharacterId ? characterName(winnerCharacterId) : null,
+          winner_movie: winnerCharacterId
+            ? characterById.get(winnerCharacterId)?.movie_title ?? null
+            : null,
+          franchise:
+            franchiseOptions.find((franchise) => franchise.franchise_id === selectedFranchiseId)
+              ?.franchise_name ?? null,
+          roster_size: state.participants.length,
+          turn_count: state.turn_number,
+          simulation_speed: runtime.settings.simulation_speed
+        });
         setInfoMessage(
-          winnerName
-            ? `Partida finalizada. Ganador: ${characterName(winnerName)}.`
+          winnerCharacterId
+            ? `Partida finalizada. Ganador: ${characterName(winnerCharacterId)}.`
             : 'Partida finalizada.'
         );
       }
@@ -862,7 +909,18 @@ export function MatchStudioPage({
     } finally {
       setIsBusy(false);
     }
-  }, [applySetupFromMatch, autosaveEnabled, characterName, isBusy, localMatches, persistLocalMatches, runtime]);
+  }, [
+    applySetupFromMatch,
+    autosaveEnabled,
+    characterById,
+    characterName,
+    franchiseOptions,
+    isBusy,
+    localMatches,
+    persistLocalMatches,
+    runtime,
+    selectedFranchiseId
+  ]);
 
   useEffect(() => {
     if (

--- a/app/new/match-studio-page.tsx
+++ b/app/new/match-studio-page.tsx
@@ -1159,7 +1159,11 @@ export function MatchStudioPage({
                     </span>
                     <span className="grid gap-1">
                       <label className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
-                        <Switch checked={autosaveEnabled} onCheckedChange={onToggleAutosave} />
+                        <Switch
+                          data-analytics-control="autosave"
+                          checked={autosaveEnabled}
+                          onCheckedChange={onToggleAutosave}
+                        />
                         Guardar local
                       </label>
                       <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
@@ -1341,6 +1345,7 @@ export function MatchStudioPage({
                       Seed (opcional)
                       <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
                       <Input
+                        data-analytics-control="match_seed"
                         value={seed}
                         onChange={(event) => setSeed(event.target.value)}
                         placeholder="manual o aleatoria"
@@ -1356,6 +1361,7 @@ export function MatchStudioPage({
                         <Label className="grid gap-2 font-mono text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
                           Perfil de eventos
                           <Select
+                            data-analytics-control="event_profile"
                             value={eventProfile}
                             onChange={(event) =>
                               setEventProfile(event.target.value as 'balanced' | 'aggressive' | 'chaotic')
@@ -1370,6 +1376,7 @@ export function MatchStudioPage({
                         <Label className="grid gap-2 font-mono text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
                           Nivel de sorpresa
                           <Select
+                            data-analytics-control="surprise_level"
                             value={surpriseLevel}
                             onChange={(event) =>
                               setSurpriseLevel(event.target.value as 'low' | 'normal' | 'high')

--- a/components/ui/button-link.tsx
+++ b/components/ui/button-link.tsx
@@ -17,7 +17,13 @@ export function ButtonLink({
   ...props
 }: ButtonLinkProps) {
   return (
-    <Link className={buttonVariants({ variant, size, className })} {...props}>
+    <Link
+      data-slot="button-link"
+      data-button-size={size}
+      data-button-variant={variant}
+      className={buttonVariants({ variant, size, className })}
+      {...props}
+    >
       {children}
     </Link>
   );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -51,6 +51,8 @@ function Button({
   return (
     <ButtonPrimitive
       data-slot="button"
+      data-button-size={size}
+      data-button-variant={variant}
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -6,8 +6,18 @@ if (posthogKey) {
   posthog.init(posthogKey, {
     api_host:
       process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+    autocapture: {
+      dom_event_allowlist: ['click', 'change', 'submit'],
+      element_allowlist: ['a', 'button', 'form', 'input', 'select', 'textarea'],
+      capture_copied_text: false
+    },
     capture_pageleave: true,
     capture_pageview: true,
+    capture_performance: true,
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: '[data-private]'
+    },
     defaults: '2026-01-30'
   });
 }

--- a/lib/product-analytics.ts
+++ b/lib/product-analytics.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import posthog from 'posthog-js';
+import packageJson from '@/package.json';
+import { RULESET_VERSION } from '@/lib/domain/types';
+
+export function captureProductEvent(
+  event: string,
+  properties?: Record<string, boolean | number | string | null>
+) {
+  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    return;
+  }
+
+  posthog.capture(event, {
+    app_version: packageJson.version,
+    ruleset_version: RULESET_VERSION,
+    environment: process.env.NODE_ENV,
+    ...properties
+  });
+}

--- a/specs/README.md
+++ b/specs/README.md
@@ -9,5 +9,6 @@ Read only what is needed:
 5. `quality.md` - validation gate.
 6. `decisions.md` - active decisions.
 7. `data.yaml` / `api.yaml` - contracts.
+8. `analytics.md` - product analytics event contracts.
 
 Rule: `/specs` decides what to build; it does not document history.

--- a/specs/analytics.md
+++ b/specs/analytics.md
@@ -1,0 +1,148 @@
+# Product Analytics
+
+PostHog is the source of truth for product analytics. The primary journey is:
+
+`match_started -> match_movie_used -> match_character_used -> match_finished`
+
+## Event Rules
+
+- Use snake_case event and property names.
+- Use one scalar value per property. Do not send arrays or multiple values in one property.
+- Include `match_id` in every match event so events can be joined into one journey.
+- Send readable catalog names. Do not send internal franchise, movie, or character IDs.
+- Do not send seeds, snapshots, custom participant names, or other user-generated content.
+- Update `ruleset_version` whenever simulation rules, probabilities, event selection, character outcomes, or winner determination behavior changes.
+
+## Common Metadata
+
+Every named product event includes:
+
+| Property | Type | Example |
+| --- | --- | --- |
+| `app_version` | string | `0.6.0` |
+| `ruleset_version` | string | `v1.0.0` |
+| `environment` | string | `production` |
+| `match_id` | string | `match-123` |
+
+Browser, operating system, device, URL, referrer, UTM, locale, and approximate location remain PostHog-managed properties.
+
+## Match Journey
+
+### `match_started`
+
+Emitted once after the match has successfully started.
+
+| Property | Type |
+| --- | --- |
+| `franchise` | string |
+| `movie_count` | number |
+| `roster_size` | number |
+| `event_profile` | string |
+| `surprise_level` | string |
+| `autosave_enabled` | boolean |
+
+Do not include `simulation_speed`; it is relevant only when analyzing a completed match.
+
+### `match_movie_used`
+
+Emitted once per selected movie after the match has successfully started.
+
+| Property | Type |
+| --- | --- |
+| `movie` | string |
+| `franchise` | string |
+
+### `match_character_used`
+
+Emitted once per roster character after the match has successfully started.
+
+| Property | Type |
+| --- | --- |
+| `character` | string |
+| `movie` | string |
+| `franchise` | string |
+
+### `match_finished`
+
+Emitted once when the match reaches `finished`.
+
+| Property | Type |
+| --- | --- |
+| `winner` | string |
+| `winner_movie` | string |
+| `franchise` | string |
+| `roster_size` | number |
+| `turn_count` | number |
+| `duration_seconds` | number |
+| `simulation_speed` | string |
+
+## Required Reports
+
+- Funnel: `match_started -> match_finished`.
+- Most-used franchises grouped by `franchise`.
+- Most-used movies grouped by `movie`.
+- Most-used characters grouped by `character`.
+- Most frequent winners grouped by `winner`.
+- Completion rate and duration grouped by `roster_size` and `simulation_speed`.
+
+## Analytics Preview
+
+Example journey for one completed match:
+
+```json
+{
+  "event": "match_started",
+  "match_id": "match-123",
+  "app_version": "0.6.0",
+  "ruleset_version": "v1.0.0",
+  "environment": "production",
+  "franchise": "Star Wars",
+  "movie_count": 1,
+  "roster_size": 2,
+  "event_profile": "balanced",
+  "surprise_level": "normal",
+  "autosave_enabled": true
+}
+```
+
+```json
+{
+  "event": "match_movie_used",
+  "match_id": "match-123",
+  "app_version": "0.6.0",
+  "ruleset_version": "v1.0.0",
+  "environment": "production",
+  "movie": "A New Hope",
+  "franchise": "Star Wars"
+}
+```
+
+```json
+{
+  "event": "match_character_used",
+  "match_id": "match-123",
+  "app_version": "0.6.0",
+  "ruleset_version": "v1.0.0",
+  "environment": "production",
+  "character": "Luke Skywalker",
+  "movie": "A New Hope",
+  "franchise": "Star Wars"
+}
+```
+
+```json
+{
+  "event": "match_finished",
+  "match_id": "match-123",
+  "app_version": "0.6.0",
+  "ruleset_version": "v1.0.0",
+  "environment": "production",
+  "winner": "Luke Skywalker",
+  "winner_movie": "A New Hope",
+  "franchise": "Star Wars",
+  "roster_size": 2,
+  "turn_count": 14,
+  "duration_seconds": 95,
+  "simulation_speed": "2x"
+}
+```

--- a/specs/analytics.md
+++ b/specs/analytics.md
@@ -26,6 +26,8 @@ Every named product event includes:
 
 Browser, operating system, device, URL, referrer, UTM, locale, and approximate location remain PostHog-managed properties.
 
+Interactive controls include a stable `data-analytics-control` attribute so PostHog autocapture identifies the control instead of reporting only a generic clicked or changed input.
+
 ## Match Journey
 
 ### `match_started`

--- a/specs/decisions.md
+++ b/specs/decisions.md
@@ -18,3 +18,14 @@
 - No fixed local match limit in V1.
 - V1 does not require user accounts.
 - Do not use CSS modules in new screens.
+
+## Analytics Responsibilities
+
+- PostHog is the product analytics source of truth. Use it for named funnel events, feature usage, retention, and debugging user flows.
+- Google Analytics 4 measures acquisition and marketing outcomes. Use it for traffic sources, campaigns, referrals, and search-related reporting.
+- Vercel Analytics measures frontend delivery and page-level performance on Vercel. Use it for Web Vitals and deployment-related regressions.
+- Cloudflare Web Analytics provides privacy-oriented, edge-observed traffic totals. Use it as an independent check for visits and page views reaching the domain.
+- Do not compare raw totals across tools as if they were equivalent; consent, blockers, bot filtering, and collection points differ.
+- A product event is added to PostHog first. Add it to GA4 only when it represents a marketing conversion.
+- Do not send roster names, seeds, snapshot contents, or other user-generated match data to analytics tools.
+- Update `ruleset_version` whenever simulation behavior changes in a way that can affect match outcomes or metrics.


### PR DESCRIPTION
## Scope

- Add named PostHog events for match start, selected movies, roster characters, and match completion.
- Attach common app, ruleset, environment, and match metadata to product events.
- Enable PostHog autocapture, performance capture, and privacy-masked session replay.
- Document the analytics event contract, reporting expectations, and ruleset versioning rule.

## User-visible behavior

- No gameplay behavior changes.
- PostHog can now report which franchises, movies, characters, and winners are used.

## Validation

- `pnpm run lint`
- `pnpm run test:unit`
- `pnpm run test:coverage`
- `pnpm run test:e2e`
- `pnpm run validate`
